### PR TITLE
Refactor navigation layout and primitive routing

### DIFF
--- a/ui/src/App.js
+++ b/ui/src/App.js
@@ -51,7 +51,6 @@ function App() {
   const [overlay, setOverlay] = React.useState(false)
   const [primitive, setPrimitive] = React.useState(undefined)
   const [sidebarOptions, setSidebarOptions] = React.useState(undefined)
-  const [widePage, setWidePage] = React.useState(false)
   const [showDeletePrompt, setShowDeletePrompt] = React.useState()
   const [showPicker, setShowPicker] = React.useState()
   const [manualInputPrompt, setManualInputPrompt] = React.useState(false)
@@ -176,7 +175,6 @@ function App() {
                 element={
                   <ApplicationLayout
                     key={`layout-${mainstore.activeWorkspaceId}-${pagePrimitive?.id ?? "none"}`}
-                    widePage={widePage}
                     workspace={mainstore.activeWorkspaceId}
                     setWorkspace={setWorkspace}
                   />
@@ -195,17 +193,12 @@ function App() {
                 <Route path="/usage" element={<UsageScreen />}/>
                 <Route path="/account" element={<AccountScreen/>}/>
                 <Route path="/queue/:id?" element={<QueuePage />}/>
-                <Route
-                  path="/workflows/:id?"
-                  element={<WorkflowDashboard widePage={widePage} setWidePage={setWidePage}/>}
-                />
+                <Route path="/workflows/:id?" element={<WorkflowDashboard/>} />
                 <Route
                   path="/item/:id"
                   element={
                     <PrimitivePageContainer
                       key={`${mainstore.activeWorkspaceId}-${pagePrimitive?.id}`}
-                      widePage={widePage}
-                      setWidePage={setWidePage}
                       selectPrimitive={selectPrimitive}
                     />
                   }

--- a/ui/src/App.js
+++ b/ui/src/App.js
@@ -1,23 +1,20 @@
 import './App.css';
 import MainStore from './MainStore';
 import React, { useEffect, useReducer } from 'react';
-import { BrowserRouter, Routes, Route, useParams, Outlet } from "react-router-dom";
-import { ComponentView } from './ComponentView';
+import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { Sidebar } from './Sidebar';
 import { library } from '@fortawesome/fontawesome-svg-core'
 //import { fas } from '@fortawesome/free-solid-svg-icons'
 import { faLinkedin } from '@fortawesome/free-brands-svg-icons'
 import { faTags, faFilter } from '@fortawesome/pro-light-svg-icons';
 import { faRobot, faTrash, faChevronDown, faCircleInfo, faSpider, faSpinner, faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
-import { PrimitivePage } from './PrimitivePage';
-import SideNav from './SideNav';
+import ApplicationLayout from './ApplicationLayout.jsx';
+import PrimitivePageContainer from './PrimitivePageContainer.jsx';
 import SignIn from './SignIn';
 import HomeScreen from './HomeScreen';
-import toast, { Toaster } from 'react-hot-toast';
 import ConfirmationPopup from './ConfirmationPopup';
 import PrimitivePicker from './PrimitivePicker';
 import { InputPopup } from './InputPopup';
-import CollectionUtils from './CollectionHelper';
 import test from './tests/filter.js';
 import NewPrimitive from './NewPrimitive.js';
 import Popup from './Popup.js';
@@ -174,34 +171,47 @@ function App() {
               <Route path="/login" element={<SignIn/>}/>
               <Route path="/signup" element={<SignupPage/>}/>
               <Route path="/reset/:id" element={<ResetPasswordPage/>}/>
-              <Route path="/" element={<SideNav workspace={mainstore.activeWorkspaceId} setWorkspace={setWorkspace}>
-                <HomeScreen workspace={mainstore.activeWorkspaceId} setWorkspace={setWorkspace}/>
-              </SideNav>}/>
               <Route path="/published/new_instance/:id" element={<FlowInstancePage />}/>
-              <Route element={
-                <SideNav key='sidebar' widePage={widePage} workspace={mainstore.activeWorkspaceId} setWorkspace={setWorkspace}>
-                    <Toaster 
-                      position="bottom-right"
-                      reverseOrder={true}
-                      gutter={8}
-                      containerClassName=""
-                      toastOptions={{
-                        className: '',
-                        style: {
-                          background: '#f3fcf6',
-                          border:'1px solid #00d967'
-                        }}}
+              <Route
+                element={
+                  <ApplicationLayout
+                    key={`layout-${mainstore.activeWorkspaceId}-${pagePrimitive?.id ?? "none"}`}
+                    widePage={widePage}
+                    workspace={mainstore.activeWorkspaceId}
+                    setWorkspace={setWorkspace}
+                  />
+                }
+              >
+                <Route
+                  index
+                  element={
+                    <HomeScreen
+                      workspace={mainstore.activeWorkspaceId}
+                      setWorkspace={setWorkspace}
                     />
-                    <Outlet/>
-                </SideNav>}>
-                  <Route path="/workflow/:id/new_instance" element={<FlowInstancePage />}/>
-                  <Route path="/usage/" element={<UsageScreen />}/>
-                  <Route path="/account/" element={<AccountScreen/>}/>
-                  <Route path="/queue/:id?" element={<QueuePage />}/>
-                  <Route path="/workflows/:id?" element={<WorkflowDashboard widePage={widePage} setWidePage={setWidePage}/>}/>
-                  <Route path="/item/:id" element={<PrimitivePage key={`${mainstore.activeWorkspaceId}-${pagePrimitive?.id}`} widePage={widePage} setWidePage={setWidePage} selectPrimitive={selectPrimitive}/>}/>
-                  <Route path="/project/:id" element={<ProjectScreen/>}/>
-                </Route>
+                  }
+                />
+                <Route path="/workflow/:id/new_instance" element={<FlowInstancePage />}/>
+                <Route path="/usage" element={<UsageScreen />}/>
+                <Route path="/account" element={<AccountScreen/>}/>
+                <Route path="/queue/:id?" element={<QueuePage />}/>
+                <Route
+                  path="/workflows/:id?"
+                  element={<WorkflowDashboard widePage={widePage} setWidePage={setWidePage}/>}
+                />
+                <Route
+                  path="/item/:id"
+                  element={
+                    <PrimitivePageContainer
+                      key={`${mainstore.activeWorkspaceId}-${pagePrimitive?.id}`}
+                      widePage={widePage}
+                      setWidePage={setWidePage}
+                      selectPrimitive={selectPrimitive}
+                    />
+                  }
+                />
+                <Route path="/project/:id" element={<ProjectScreen/>}/>
+              </Route>
             </Routes>
           <Sidebar open={open} fixed={allowFixedSidebar} overlay={true} setOpen={(v)=>{selectPrimitive(null)}} primitive={primitive} {...(sidebarOptions ||{})}/>
           {showDeletePrompt && <ConfirmationPopup title={showDeletePrompt.title ?? "Confirm deletion"} message={showDeletePrompt.prompt} confirm={showDeletePrompt.handleDelete} cancel={()=>setShowDeletePrompt(false)}/>}

--- a/ui/src/ApplicationLayout.jsx
+++ b/ui/src/ApplicationLayout.jsx
@@ -344,7 +344,6 @@ export default function ApplicationLayout({
       <div className="border-t border-default-200 px-6 py-5">
         <Dropdown
           placement="top"
-          onAction={(key) => handleUserAction(key, closeDrawer)}
         >
           <DropdownTrigger>
             <Button variant="light" className="w-full justify-start gap-3">
@@ -364,7 +363,10 @@ export default function ApplicationLayout({
               </div>
             </Button>
           </DropdownTrigger>
-          <DropdownMenu aria-label="Profile actions" variant="flat">
+          <DropdownMenu 
+              onAction={(key) => handleUserAction(key, closeDrawer)}
+              aria-label="Profile actions" 
+              variant="flat">
             <DropdownItem key="account">Account settings</DropdownItem>
             <DropdownItem key="logout" color="danger">
               Log out
@@ -429,7 +431,7 @@ export default function ApplicationLayout({
               <div className="rounded-lg border border-default-200 bg-default-100 px-3 py-1 text-xs text-default-500">
                 Credits: <span className="font-semibold text-default-700">{creditsAvailable}</span>
               </div>
-              <Dropdown onAction={(key) => handleUserAction(key)} placement="bottom-end">
+              <Dropdown>
                 <DropdownTrigger>
                   <Button isIconOnly variant="light" className="border border-default-200">
                     <Avatar
@@ -440,7 +442,7 @@ export default function ApplicationLayout({
                     />
                   </Button>
                 </DropdownTrigger>
-                <DropdownMenu aria-label="Profile actions" variant="flat">
+                <DropdownMenu onAction={(key) => handleUserAction(key)} placement="bottom-end" aria-label="Profile actions" variant="flat">
                   <DropdownItem key="account">Account settings</DropdownItem>
                   <DropdownItem key="logout" color="danger">
                     Log out

--- a/ui/src/ApplicationLayout.jsx
+++ b/ui/src/ApplicationLayout.jsx
@@ -1,21 +1,31 @@
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import {
-  Navbar,
-  NavbarBrand,
-  NavbarContent,
-  NavbarMenu,
-  NavbarMenuItem,
-  NavbarMenuToggle,
+  Avatar,
   Button,
+  Divider,
+  Drawer as SidebarDrawer,
+  DrawerBody,
+  DrawerContent,
+  Dropdown,
+  DropdownItem,
+  DropdownMenu,
+  DropdownTrigger,
   Select,
   SelectItem,
-  Divider,
 } from "@heroui/react";
 import { Outlet, useLocation, useNavigate } from "react-router-dom";
-import { HomeIcon, SparklesIcon, ArrowDownTrayIcon } from "@heroicons/react/24/outline";
+import {
+  ArrowDownTrayIcon,
+  Bars3Icon,
+  HomeIcon,
+  SparklesIcon,
+  XMarkIcon,
+} from "@heroicons/react/24/outline";
 import { Logo } from "./logo";
 import MainStore from "./MainStore";
+import PrimitiveConfig from "./PrimitiveConfig";
 import { Toaster } from "react-hot-toast";
+import { Icon } from "@iconify/react";
 
 const mainstore = MainStore();
 
@@ -34,8 +44,8 @@ function NavigationButtons({ items, onNavigate, orientation = "column" }) {
           key={item.key}
           variant={item.current ? "solid" : "light"}
           color={item.current ? "primary" : "default"}
-          startContent={<item.icon className={`${NAV_ICON_SIZE}`} />}
-          className={`justify-start ${orientation === "row" ? "" : "w-full"}`}
+          startContent={<item.icon className={NAV_ICON_SIZE} />}
+          className={orientation === "row" ? "" : "w-full justify-start"}
           onPress={() => onNavigate(item)}
         >
           {item.name}
@@ -45,10 +55,63 @@ function NavigationButtons({ items, onNavigate, orientation = "column" }) {
   );
 }
 
-function WorkspaceSelect({ workspace, workspaces, onChange, size = "sm" }) {
-  const selectedKeys = workspace
-    ? new Set([String(workspace)])
-    : new Set();
+function WorkspaceSelect({ workspace, workspaces, onChange, size = "md" }) {
+  const selectedKeys = workspace ? new Set([String(workspace)]) : new Set();
+
+  const renderVisual = (space, isBordered = true) => {
+    if (!space) {
+      return (
+        <span className="inline-flex h-3 w-3 rounded-full border border-default-200 bg-default-200" />
+      );
+    }
+    const color = space.color || "#2563eb";
+    const icon = space.icon;
+    const imageUrl = space.imageUrl;
+    if (icon) {
+      return (
+        <Icon
+          icon={icon}
+          className="h-4 w-4"
+          style={{ color }}
+          aria-hidden="true"
+        />
+      );
+    }else if (imageUrl) {
+      return (
+       <Avatar
+        isBordered={isBordered}
+        className="h-5 w-5 logo"
+        src={imageUrl}
+      />
+      );
+    }
+    return (
+       <div className="flex h-5 inline-flex justify-center place-items-center w-5">
+        <span
+          className="inline-flex h-3 w-3 rounded-full border border-default-200"
+          style={{ backgroundColor: color }}
+          aria-hidden="true"
+          />
+        </div>
+    );
+  };
+
+  const renderValue = (items) => {
+    if (items.length === 0) {
+      return <span className="text-default-400">Select workspace</span>;
+    }
+    const selected = workspaces.find(
+      (space) => String(space.id) === String(items[0].key)
+    );
+    return (
+      <div className="flex items-center gap-2">
+        {renderVisual(selected, false)}
+        <span className="truncate text-sm font-medium text-default-700">
+          {selected?.title ?? items[0].textValue}
+        </span>
+      </div>
+    );
+  };
 
   return (
     <Select
@@ -59,6 +122,7 @@ function WorkspaceSelect({ workspace, workspaces, onChange, size = "sm" }) {
       selectionMode="single"
       size={size}
       variant="bordered"
+      renderValue={renderValue}
       onSelectionChange={(keys) => {
         const [key] = Array.from(keys ?? []);
         if (key) {
@@ -67,7 +131,22 @@ function WorkspaceSelect({ workspace, workspaces, onChange, size = "sm" }) {
       }}
     >
       {workspaces.map((space) => (
-        <SelectItem key={String(space.id)}>{space.title}</SelectItem>
+        <SelectItem
+          key={String(space.id)}
+          textValue={space.title}
+          startContent={renderVisual(space)}
+        >
+          <div className="flex flex-col">
+            <span className="text-sm font-medium text-default-700">
+              {space.title}
+            </span>
+            {space.description && (
+              <span className="text-xs text-default-400 truncate">
+                {space.description}
+              </span>
+            )}
+          </div>
+        </SelectItem>
       ))}
     </Select>
   );
@@ -120,130 +199,290 @@ function useNavigationItems(workspaceId, locationPath) {
 }
 
 export default function ApplicationLayout({
-  widePage,
   workspace,
   setWorkspace,
   children,
 }) {
   const location = useLocation();
+  const routerNavigate = useNavigate();
+  const path = location.pathname;
+
+  let layoutPrimitive;
+  const itemMatch = path.match(/^\/item\/([^/]+)/);
+  if (itemMatch) {
+    const rawId = itemMatch[1];
+    const parsedId = Number.isNaN(Number(rawId)) ? rawId : Number(rawId);
+    layoutPrimitive = mainstore.primitive(parsedId);
+  }
+
+  const widePage = useMemo(() => {
+    if (path.startsWith("/login") || path.startsWith("/signup")) {
+      return false;
+    }
+    if (
+      path.startsWith("/workflows") ||
+      path.startsWith("/usage") ||
+      path.startsWith("/account") ||
+      path.startsWith("/queue") ||
+      path.startsWith("/project")
+    ) {
+      return false;
+    }
+
+    if (layoutPrimitive) {
+      const alwaysWideTypes = new Set(["board", "flow", "flowinstance", "working", "page"]);
+      if (alwaysWideTypes.has(layoutPrimitive.type)) {
+        return true;
+      }
+      if (PrimitiveConfig.pageview?.[layoutPrimitive.type]?.defaultWide) {
+        return true;
+      }
+    }
+
+    return false;
+  }, [layoutPrimitive?.id, layoutPrimitive?.type, path]);
   const workspaces = useMemo(() => {
     const ids = mainstore.activeUser?.info?.workspaces ?? [];
     return ids
       .map((id) => mainstore.workspace(id))
       .filter(Boolean)
-      .map((space) => ({ id: space.id, title: space.title }));
+      .map((space) => ({
+        id: space.id,
+        title: space.title,
+        description: space.metadata?.description,
+        icon: space.metadata?.icon || space.icon,
+        imageUrl: space.logoUrl,
+        color:
+          space.metadata?.color || space.color || space.themeColor || "#2563eb",
+      }));
   }, [mainstore.activeUser?.info?.workspaces]);
 
   const navigationItems = useNavigationItems(workspace, location.pathname);
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const isFullWidth = !!widePage;
+  const showStaticSidebar = !isFullWidth;
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
 
   const handleNavigate = useCallback(
-    (item) => {
+    (item, closeDrawer) => {
       item.onClick?.();
-      setIsMenuOpen(false);
+      closeDrawer?.();
+      setIsDrawerOpen(false);
     },
-    [setIsMenuOpen]
+    []
   );
 
   const handleWorkspaceChange = useCallback(
-    (id) => {
-      const parsed = isNaN(id) ? id : parseInt(id, 10);
-      setWorkspace(parsed);
-      setIsMenuOpen(false);
+    (id, closeDrawer) => {
+      setWorkspace(id);
+      routerNavigate(`/project/${mainstore.activeWorkspaceId}`)
+      closeDrawer?.();
+      setIsDrawerOpen(false);
     },
     [setWorkspace]
   );
 
-  const shouldShowSidebar = !(widePage === true || widePage === "always");
+  const handleUserAction = useCallback(
+    (key, closeDrawer) => {
+      if (key === "account") {
+        routerNavigate("/account");
+      } else if (key === "logout") {
+        window.location.href = "/logout";
+      }
+      closeDrawer?.();
+      setIsDrawerOpen(false);
+    },
+    [routerNavigate]
+  );
+
+  useEffect(() => {
+    setIsDrawerOpen(false);
+  }, [isFullWidth]);
+
+  const creditsAvailable = mainstore.activeOrganization?.credits ?? 0;
+  const userInfo = mainstore.activeUser?.info;
+
+  const renderNavigation = (closeDrawer) => (
+    <div className="flex h-full flex-col">
+      <div className="flex items-center justify-between gap-2 px-6 py-5">
+        <div className="flex items-center gap-2">
+          <Logo className="h-9 w-9" />
+           <p className="font-['Poppins'] font-black font-family-[Poppins] text-xl lg:text-2xl">SENSE</p>
+        </div>
+        {closeDrawer && (
+          <Button
+            isIconOnly
+            variant="light"
+            size="sm"
+            onPress={closeDrawer}
+            className="shadow-sm"
+          >
+            <XMarkIcon className="h-5 w-5" />
+          </Button>
+        )}
+      </div>
+      <div className="px-6 pb-4 space-y-4">
+        <WorkspaceSelect
+          workspace={workspace}
+          workspaces={workspaces}
+          onChange={(id) => handleWorkspaceChange(id, closeDrawer)}
+        />
+      </div>
+      <Divider />
+      <div className="flex-1 overflow-y-auto px-4 pb-6">
+        <NavigationButtons
+          items={navigationItems}
+          onNavigate={(item) => handleNavigate(item, closeDrawer)}
+        />
+      </div>
+      <Divider />
+      <div className="px-6 py-4">
+        <div className="rounded-lg border border-default-200 bg-default-100 px-4 py-3 text-sm text-default-600">
+          <span className="block text-xs uppercase tracking-wide text-default-400">Credits available</span>
+          <span className="text-lg font-semibold text-default-700">{creditsAvailable}</span>
+        </div>
+        </div>
+      <div className="border-t border-default-200 px-6 py-5">
+        <Dropdown
+          placement="top"
+          onAction={(key) => handleUserAction(key, closeDrawer)}
+        >
+          <DropdownTrigger>
+            <Button variant="light" className="w-full justify-start gap-3">
+              <Avatar
+                radius="full"
+                size="sm"
+                src={userInfo?.avatarUrl}
+                className="border border-default-200"
+              />
+              <div className="min-w-0 text-left">
+                <p className="truncate text-sm font-medium text-default-700">
+                  {userInfo?.name ?? "User"}
+                </p>
+                <p className="truncate text-xs text-default-400">
+                  {mainstore.activeOrganization?.name ?? ""}
+                </p>
+              </div>
+            </Button>
+          </DropdownTrigger>
+          <DropdownMenu aria-label="Profile actions" variant="flat">
+            <DropdownItem key="account">Account settings</DropdownItem>
+            <DropdownItem key="logout" color="danger">
+              Log out
+            </DropdownItem>
+          </DropdownMenu>
+        </Dropdown>
+      </div>
+    </div>
+  );
+
+  const outletElement = children ?? <Outlet context={{ widePage }} />;
+
+  const pageTitle = layoutPrimitive?.title ?? "";
 
   return (
     <div className="flex h-screen w-full bg-gray-50">
-      {shouldShowSidebar && (
-        <aside className="hidden h-full w-72 flex-shrink-0 border-r border-divider bg-white lg:flex lg:flex-col">
-          <div className="flex items-center gap-2 px-6 py-5">
-            <Logo className="h-7 w-7" />
-            <span className="text-lg font-semibold">Sense</span>
-          </div>
-          <div className="px-6">
-            <WorkspaceSelect
-              workspace={workspace}
-              workspaces={workspaces}
-              onChange={handleWorkspaceChange}
-            />
-          </div>
-          <Divider className="mt-4" />
-          <div className="flex-1 overflow-y-auto px-4">
-            <NavigationButtons
-              items={navigationItems}
-              onNavigate={handleNavigate}
-            />
-          </div>
+      {showStaticSidebar && (
+        <aside className="hidden h-full w-72 flex-shrink-0 flex-col border-r border-divider bg-white lg:flex">
+          {renderNavigation(null)}
         </aside>
       )}
-      <div className="flex min-w-0 flex-1 flex-col">
-        <Navbar
-          isBordered
-          maxWidth="full"
-          isMenuOpen={isMenuOpen}
-          onMenuOpenChange={setIsMenuOpen}
-          className="bg-white"
-        >
-          <NavbarContent
-            justify="start"
-            className={shouldShowSidebar ? "lg:hidden" : ""}
-          >
-            <NavbarMenuToggle aria-label="Toggle navigation" />
-          </NavbarContent>
-          <NavbarBrand className="items-center gap-2">
-            <Logo className="h-6 w-6" />
-            <p className="font-semibold">Sense</p>
-          </NavbarBrand>
-          <NavbarContent className="hidden gap-2 lg:flex" justify="start">
-            <NavigationButtons
-              items={navigationItems}
-              onNavigate={handleNavigate}
-              orientation="row"
-            />
-          </NavbarContent>
-          <NavbarContent justify="end" className="gap-4">
-            <div className="min-w-[180px]">
-              <WorkspaceSelect
-                workspace={workspace}
-                workspaces={workspaces}
-                onChange={handleWorkspaceChange}
+
+      <SidebarDrawer
+        placement="left"
+        isOpen={isDrawerOpen}
+        onOpenChange={setIsDrawerOpen}
+        hideCloseButton
+        backdrop="blur"
+        size="sm"
+        classNames={{
+          base: "h-full max-h-none w-72 max-w-none rounded-none border-r border-divider bg-white",
+          wrapper: "z-[60]",
+        }}
+      >
+        <DrawerContent>
+          {(onClose) => (
+            <DrawerBody className="p-0">
+              {renderNavigation(onClose)}
+            </DrawerBody>
+          )}
+        </DrawerContent>
+      </SidebarDrawer>
+
+      <div className="relative flex min-w-0 flex-1 flex-col overflow-hidden">
+        {isFullWidth ? (
+          <header className="sticky top-0 z-40 flex h-14 w-full items-center justify-between border-b border-default-200 bg-white/90 px-4 backdrop-blur">
+            <div className="flex items-center gap-3">
+              <Button
+                isIconOnly
+                variant="light"
                 size="sm"
-              />
+                className="border border-default-200"
+                onPress={() => setIsDrawerOpen(true)}
+              >
+                <Bars3Icon className="h-5 w-5" />
+              </Button>
+              <span className="text-sm font-medium text-default-600">
+                {pageTitle || "Navigation"}
+              </span>
             </div>
-          </NavbarContent>
-          <NavbarMenu>
-            <div className="flex flex-col gap-4 px-4 py-4">
-              <WorkspaceSelect
-                workspace={workspace}
-                workspaces={workspaces}
-                onChange={handleWorkspaceChange}
-              />
-              <Divider />
-              {navigationItems.map((item) => (
-                <NavbarMenuItem key={item.key}>
-                  <Button
-                    fullWidth
-                    variant={item.current ? "solid" : "light"}
-                    color={item.current ? "primary" : "default"}
-                    startContent={<item.icon className={`${NAV_ICON_SIZE}`} />}
-                    onPress={() => handleNavigate(item)}
-                  >
-                    {item.name}
+            <div className="flex items-center gap-3">
+              <div className="rounded-lg border border-default-200 bg-default-100 px-3 py-1 text-xs text-default-500">
+                Credits: <span className="font-semibold text-default-700">{creditsAvailable}</span>
+              </div>
+              <Dropdown onAction={(key) => handleUserAction(key)} placement="bottom-end">
+                <DropdownTrigger>
+                  <Button isIconOnly variant="light" className="border border-default-200">
+                    <Avatar
+                      radius="full"
+                      size="sm"
+                      src={userInfo?.avatarUrl}
+                      className="border border-default-200"
+                    />
                   </Button>
-                </NavbarMenuItem>
-              ))}
+                </DropdownTrigger>
+                <DropdownMenu aria-label="Profile actions" variant="flat">
+                  <DropdownItem key="account">Account settings</DropdownItem>
+                  <DropdownItem key="logout" color="danger">
+                    Log out
+                  </DropdownItem>
+                </DropdownMenu>
+              </Dropdown>
             </div>
-          </NavbarMenu>
-        </Navbar>
-        <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-          <main className="flex-1 overflow-hidden bg-gray-100">
-            {children ?? <Outlet />}
-          </main>
-        </div>
+          </header>
+        ) : (
+          <header className="sticky top-0 z-30 flex h-14 items-center justify-between border-b border-default-200 bg-white/90 px-4 backdrop-blur lg:hidden">
+            <Button
+              isIconOnly
+              variant="light"
+              size="sm"
+              className="border border-default-200"
+              onPress={() => setIsDrawerOpen(true)}
+            >
+              <Bars3Icon className="h-5 w-5" />
+            </Button>
+            <span className="text-sm font-semibold text-default-700">Sense</span>
+            <Dropdown onAction={(key) => handleUserAction(key)} placement="bottom-end">
+              <DropdownTrigger>
+                <Button isIconOnly variant="light" className="border border-default-200">
+                  <Avatar
+                    radius="full"
+                    size="sm"
+                    src={userInfo?.avatarUrl}
+                    className="border border-default-200"
+                  />
+                </Button>
+              </DropdownTrigger>
+              <DropdownMenu aria-label="Profile actions" variant="flat">
+                <DropdownItem key="account">Account settings</DropdownItem>
+                <DropdownItem key="logout" color="danger">
+                  Log out
+                </DropdownItem>
+              </DropdownMenu>
+            </Dropdown>
+          </header>
+        )}
+
+        <main className="flex-1 overflow-hidden bg-gray-100">{outletElement}</main>
       </div>
       <Toaster
         position="bottom-right"

--- a/ui/src/ApplicationLayout.jsx
+++ b/ui/src/ApplicationLayout.jsx
@@ -1,0 +1,262 @@
+import React, { useCallback, useMemo, useState } from "react";
+import {
+  Navbar,
+  NavbarBrand,
+  NavbarContent,
+  NavbarMenu,
+  NavbarMenuItem,
+  NavbarMenuToggle,
+  Button,
+  Select,
+  SelectItem,
+  Divider,
+} from "@heroui/react";
+import { Outlet, useLocation, useNavigate } from "react-router-dom";
+import { HomeIcon, SparklesIcon, ArrowDownTrayIcon } from "@heroicons/react/24/outline";
+import { Logo } from "./logo";
+import MainStore from "./MainStore";
+import { Toaster } from "react-hot-toast";
+
+const mainstore = MainStore();
+
+const NAV_ICON_SIZE = "h-4 w-4";
+
+function NavigationButtons({ items, onNavigate, orientation = "column" }) {
+  const layoutClass =
+    orientation === "row"
+      ? "flex-row items-center gap-2"
+      : "flex-col gap-2 py-2";
+
+  return (
+    <div className={`flex ${layoutClass}`}>
+      {items.map((item) => (
+        <Button
+          key={item.key}
+          variant={item.current ? "solid" : "light"}
+          color={item.current ? "primary" : "default"}
+          startContent={<item.icon className={`${NAV_ICON_SIZE}`} />}
+          className={`justify-start ${orientation === "row" ? "" : "w-full"}`}
+          onPress={() => onNavigate(item)}
+        >
+          {item.name}
+        </Button>
+      ))}
+    </div>
+  );
+}
+
+function WorkspaceSelect({ workspace, workspaces, onChange, size = "sm" }) {
+  const selectedKeys = workspace
+    ? new Set([String(workspace)])
+    : new Set();
+
+  return (
+    <Select
+      aria-label="Select workspace"
+      selectedKeys={selectedKeys}
+      className="w-full"
+      disallowEmptySelection={workspaces.length > 0}
+      selectionMode="single"
+      size={size}
+      variant="bordered"
+      onSelectionChange={(keys) => {
+        const [key] = Array.from(keys ?? []);
+        if (key) {
+          onChange(key);
+        }
+      }}
+    >
+      {workspaces.map((space) => (
+        <SelectItem key={String(space.id)}>{space.title}</SelectItem>
+      ))}
+    </Select>
+  );
+}
+
+function useNavigationItems(workspaceId, locationPath) {
+  const navigate = useNavigate();
+
+  return useMemo(() => {
+    const baseItems = [
+      {
+        key: "home",
+        name: "Home",
+        icon: HomeIcon,
+        onClick: () => navigate("/"),
+        current: locationPath === "/",
+      },
+      mainstore.activeWorkspaceId && !mainstore.activeUser?.info?.external
+        ? {
+            key: "project",
+            name: "Project Home",
+            icon: SparklesIcon,
+            onClick: () => navigate(`/project/${mainstore.activeWorkspaceId}`),
+            current: locationPath.startsWith("/project"),
+          }
+        : null,
+      {
+        key: "workflows",
+        name: "Workflows",
+        icon: SparklesIcon,
+        onClick: () =>
+          navigate(
+            mainstore.activeWorkspaceId
+              ? `/workflows/${mainstore.activeWorkspaceId}`
+              : "/workflows"
+          ),
+        current: locationPath.startsWith("/workflows"),
+      },
+      {
+        key: "usage",
+        name: "Usage",
+        icon: ArrowDownTrayIcon,
+        onClick: () => navigate("/usage"),
+        current: locationPath.startsWith("/usage"),
+      },
+    ];
+
+    return baseItems.filter(Boolean);
+  }, [locationPath, navigate, workspaceId]);
+}
+
+export default function ApplicationLayout({
+  widePage,
+  workspace,
+  setWorkspace,
+  children,
+}) {
+  const location = useLocation();
+  const workspaces = useMemo(() => {
+    const ids = mainstore.activeUser?.info?.workspaces ?? [];
+    return ids
+      .map((id) => mainstore.workspace(id))
+      .filter(Boolean)
+      .map((space) => ({ id: space.id, title: space.title }));
+  }, [mainstore.activeUser?.info?.workspaces]);
+
+  const navigationItems = useNavigationItems(workspace, location.pathname);
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+
+  const handleNavigate = useCallback(
+    (item) => {
+      item.onClick?.();
+      setIsMenuOpen(false);
+    },
+    [setIsMenuOpen]
+  );
+
+  const handleWorkspaceChange = useCallback(
+    (id) => {
+      const parsed = isNaN(id) ? id : parseInt(id, 10);
+      setWorkspace(parsed);
+      setIsMenuOpen(false);
+    },
+    [setWorkspace]
+  );
+
+  const shouldShowSidebar = !(widePage === true || widePage === "always");
+
+  return (
+    <div className="flex h-screen w-full bg-gray-50">
+      {shouldShowSidebar && (
+        <aside className="hidden h-full w-72 flex-shrink-0 border-r border-divider bg-white lg:flex lg:flex-col">
+          <div className="flex items-center gap-2 px-6 py-5">
+            <Logo className="h-7 w-7" />
+            <span className="text-lg font-semibold">Sense</span>
+          </div>
+          <div className="px-6">
+            <WorkspaceSelect
+              workspace={workspace}
+              workspaces={workspaces}
+              onChange={handleWorkspaceChange}
+            />
+          </div>
+          <Divider className="mt-4" />
+          <div className="flex-1 overflow-y-auto px-4">
+            <NavigationButtons
+              items={navigationItems}
+              onNavigate={handleNavigate}
+            />
+          </div>
+        </aside>
+      )}
+      <div className="flex min-w-0 flex-1 flex-col">
+        <Navbar
+          isBordered
+          maxWidth="full"
+          isMenuOpen={isMenuOpen}
+          onMenuOpenChange={setIsMenuOpen}
+          className="bg-white"
+        >
+          <NavbarContent
+            justify="start"
+            className={shouldShowSidebar ? "lg:hidden" : ""}
+          >
+            <NavbarMenuToggle aria-label="Toggle navigation" />
+          </NavbarContent>
+          <NavbarBrand className="items-center gap-2">
+            <Logo className="h-6 w-6" />
+            <p className="font-semibold">Sense</p>
+          </NavbarBrand>
+          <NavbarContent className="hidden gap-2 lg:flex" justify="start">
+            <NavigationButtons
+              items={navigationItems}
+              onNavigate={handleNavigate}
+              orientation="row"
+            />
+          </NavbarContent>
+          <NavbarContent justify="end" className="gap-4">
+            <div className="min-w-[180px]">
+              <WorkspaceSelect
+                workspace={workspace}
+                workspaces={workspaces}
+                onChange={handleWorkspaceChange}
+                size="sm"
+              />
+            </div>
+          </NavbarContent>
+          <NavbarMenu>
+            <div className="flex flex-col gap-4 px-4 py-4">
+              <WorkspaceSelect
+                workspace={workspace}
+                workspaces={workspaces}
+                onChange={handleWorkspaceChange}
+              />
+              <Divider />
+              {navigationItems.map((item) => (
+                <NavbarMenuItem key={item.key}>
+                  <Button
+                    fullWidth
+                    variant={item.current ? "solid" : "light"}
+                    color={item.current ? "primary" : "default"}
+                    startContent={<item.icon className={`${NAV_ICON_SIZE}`} />}
+                    onPress={() => handleNavigate(item)}
+                  >
+                    {item.name}
+                  </Button>
+                </NavbarMenuItem>
+              ))}
+            </div>
+          </NavbarMenu>
+        </Navbar>
+        <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+          <main className="flex-1 overflow-hidden bg-gray-100">
+            {children ?? <Outlet />}
+          </main>
+        </div>
+      </div>
+      <Toaster
+        position="bottom-right"
+        reverseOrder={true}
+        gutter={8}
+        toastOptions={{
+          className: "",
+          style: {
+            background: "#f3fcf6",
+            border: "1px solid #00d967",
+          },
+        }}
+      />
+    </div>
+  );
+}

--- a/ui/src/PrimitivePage.js
+++ b/ui/src/PrimitivePage.js
@@ -31,27 +31,6 @@ import RouterTest from './RouterTest';
 
 let mainstore = MainStore()
 
-const comments = [
-  {
-    id: 1,
-    date: '4d ago',
-    userId: 4,
-    body: 'Ducimus quas delectus ad maxime totam doloribus reiciendis ex. Tempore dolorem maiores. Similique voluptatibus tempore non ut.',
-  },
-  {
-    id: 2,
-    date: '4d ago',
-    userId: 2,
-    body: 'Et ut autem. Voluptatem eum dolores sint necessitatibus quos. Quis eum qui dolorem accusantium voluptas voluptatem ipsum. Quo facere iusto quia accusamus veniam id explicabo et aut.',
-  },
-  {
-    id: 3,
-    date: '4d ago',
-    userId: 3,
-    body: 'Expedita consequatur sit ea voluptas quo ipsam recusandae. Ab sint et voluptatem repudiandae voluptatem et eveniet. Nihil quas consequatur autem. Perferendis rerum et.',
-  },
-]
-
 function classNames(...classes) {
   return classes.filter(Boolean).join(' ')
 }
@@ -59,9 +38,6 @@ function classNames(...classes) {
 
 
 export function PrimitivePage({primitive, ...props}) {
-    if (!primitive) {
-      return null;
-    }
     //let metadata = primitive.metadata
     let task = primitive.originTask
     //let origin = task && (primitive.originId !== task.id) ? primitive.origin : undefined
@@ -103,11 +79,7 @@ export function PrimitivePage({primitive, ...props}) {
     const setShowWorkingPane = useCallback((value) => {
       if( value === false && hasDocumentViewer){value = true}
       setShowWorkingPaneReal(value)
-      if( props.setWidePage ){
-        const fullScreenExplore = PrimitiveConfig.pageview[primitive.type]?.defaultWide ?? doFullScreenExplore(value) 
-        props.setWidePage( fullScreenExplore ? "always" : value )
-      }
-    })
+    }, [hasDocumentViewer])
 
     useDataEvent("relationship_update set_field set_parameter", primitive.id, updateRelationships)
 
@@ -169,6 +141,12 @@ export function PrimitivePage({primitive, ...props}) {
       }
     },[componentView])
 
+    let page = useRef()
+    let header = useRef()
+
+    if (!primitive) {
+      return null;
+    }
 
 
     const setLocalMetric = (id)=>{
@@ -177,8 +155,6 @@ export function PrimitivePage({primitive, ...props}) {
     }
 
 
-    let page = useRef()
-    let header = useRef()
 
     let outcomesList = primitive.isTask ? primitive.primitives.outcomes.allUniqueEvidence : primitive.primitives.origin.allUniqueEvidence
     

--- a/ui/src/PrimitivePage.js
+++ b/ui/src/PrimitivePage.js
@@ -2,7 +2,7 @@ import { PrimitiveCard } from './PrimitiveCard'
 import { MetricCard } from './MetricCard'
 import { HeroIcon } from './HeroIcon'
 import {Fragment, useEffect, useReducer, useRef, useState, useMemo, useCallback, useLayoutEffect} from 'react';
-import { useLinkClickHandler, useNavigate, useParams } from "react-router-dom";
+import { useLinkClickHandler, useNavigate } from "react-router-dom";
 import Panel from './Panel';
 import { Tab, Transition } from '@headlessui/react'
 import {
@@ -25,12 +25,8 @@ import PrimitiveConfig from './PrimitiveConfig';
 import VFTable from './VFTable';
 import MapViewer from './MapViewer';
 import BoardViewer from './BoardViewer';
-import AnalysisPage from './AnalysisPage';
-import FlowPage from './FlowPage';
 import ReportViewExporter from './ReportViewExporter';
 import RouterTest from './RouterTest';
-import FlowInstancePage from './FlowInstancePage';
-import PageView from './PageView';
 
 
 let mainstore = MainStore()
@@ -63,9 +59,8 @@ function classNames(...classes) {
 
 
 export function PrimitivePage({primitive, ...props}) {
-    const { id } = useParams();
-    if( primitive === undefined && id){
-      primitive = mainstore.primitive(isNaN(id) ? id : parseInt(id))
+    if (!primitive) {
+      return null;
     }
     //let metadata = primitive.metadata
     let task = primitive.originTask
@@ -383,23 +378,6 @@ export function PrimitivePage({primitive, ...props}) {
       )
     }
   
-  if( primitive?.type === "page" ){
-    return <PageView primitive={primitive}/>
-  }
-
-  if( primitive?.type === "working" ){
-    return <AnalysisPage primitive={primitive}/>
-  }
-  if(primitive?.type === "flow"  ){
-    //return <FlowPage primitive={primitive}/>
-    return <div className={`h-[calc(100vh_-_4em)] p-4`}>
-              <BoardViewer primitive={primitive}/>
-            </div>
-  }
-  if( primitive?.type === "flowinstance"  ){
-    return <FlowInstancePage primitive={primitive}/>
-  }
-
   return (
     <>
       <div 

--- a/ui/src/PrimitivePageContainer.jsx
+++ b/ui/src/PrimitivePageContainer.jsx
@@ -1,0 +1,61 @@
+import React, { useMemo } from "react";
+import { useParams } from "react-router-dom";
+import { Spinner } from "@heroui/react";
+import MainStore from "./MainStore";
+import { PrimitivePage } from "./PrimitivePage";
+import PageView from "./PageView";
+import AnalysisPage from "./AnalysisPage";
+import FlowInstancePage from "./FlowInstancePage";
+import BoardViewer from "./BoardViewer";
+
+const mainstore = MainStore();
+
+function renderPrimitiveByType(primitive, props) {
+  if (!primitive) {
+    return null;
+  }
+
+  switch (primitive.type) {
+    case "page":
+      return <PageView primitive={primitive} {...props} />;
+    case "working":
+      return <AnalysisPage primitive={primitive} {...props} />;
+    case "flow":
+      return (
+        <div className="h-[calc(100vh_-_4em)] p-4">
+          <BoardViewer primitive={primitive} />
+        </div>
+      );
+    case "flowinstance":
+      return <FlowInstancePage primitive={primitive} {...props} />;
+    default:
+      return <PrimitivePage primitive={primitive} {...props} />;
+  }
+}
+
+export default function PrimitivePageContainer(props) {
+  const { id } = useParams();
+
+  const primitive = useMemo(() => {
+    if (props.primitive) {
+      return props.primitive;
+    }
+
+    if (!id) {
+      return undefined;
+    }
+
+    const parsedId = isNaN(id) ? id : parseInt(id, 10);
+    return mainstore.primitive(parsedId);
+  }, [id, props.primitive]);
+
+  if (!primitive) {
+    return (
+      <div className="flex h-full w-full items-center justify-center bg-gray-100">
+        <Spinner color="primary" label="Loading primitive" />
+      </div>
+    );
+  }
+
+  return renderPrimitiveByType(primitive, props);
+}

--- a/ui/src/PrimitivePageContainer.jsx
+++ b/ui/src/PrimitivePageContainer.jsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from "react";
-import { useParams } from "react-router-dom";
+import { useOutletContext, useParams } from "react-router-dom";
 import { Spinner } from "@heroui/react";
 import MainStore from "./MainStore";
 import { PrimitivePage } from "./PrimitivePage";
@@ -35,6 +35,8 @@ function renderPrimitiveByType(primitive, props) {
 
 export default function PrimitivePageContainer(props) {
   const { id } = useParams();
+  const outletContext = useOutletContext() || {};
+  const widePage = outletContext.widePage ?? false;
 
   const primitive = useMemo(() => {
     if (props.primitive) {
@@ -57,5 +59,10 @@ export default function PrimitivePageContainer(props) {
     );
   }
 
-  return renderPrimitiveByType(primitive, props);
+  const pageProps = {
+    ...props,
+    widePage,
+  };
+
+  return renderPrimitiveByType(primitive, pageProps);
 }

--- a/ui/src/WorkflowDashboard.js
+++ b/ui/src/WorkflowDashboard.js
@@ -16,11 +16,10 @@ import { Button } from "@heroui/react"
 import { Icon } from "@iconify/react/dist/iconify.js"
 import FlowInstanceEditor from "./FlowInstanceEditor"
 
-export default function WorkflowDashboard(props){
+export default function WorkflowDashboard(){
     const navigate = useNavigate()        
     const [showNew, setShowNew] = useState(false)
     const [editFlowInstance, setEditFlowInstance] = useState(false)
-    props.setWidePage(false)
 
     const {id} = useParams()
 
@@ -34,11 +33,13 @@ export default function WorkflowDashboard(props){
     
 
 
+    const activeWorkspaceId = MainStore().activeWorkspaceId
+
     const filterForWorksapce = (array)=>{
-        if( props.workspace === undefined ){
+        if( activeWorkspaceId === undefined ){
             return array
         }
-        return array.filter((d)=>d.workspaceId === props.workspace.id)
+        return array.filter((d)=>d.workspaceId === activeWorkspaceId)
     }
 
     useEffect(()=>{

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -25,4 +25,3 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }
-


### PR DESCRIPTION
## Summary
- replace the old SideNav wrapper with a new HeroUI-based ApplicationLayout that supports both sidebar and burger-menu navigation modes
- route primitive type rendering through a dedicated PrimitivePageContainer so PrimitivePage only handles shared page layout
- update App routing to use the new layout and container components and simplify PrimitivePage to expect a supplied primitive

## Testing
- `npm run build` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68de410fcf3c8330bf87cd0613026f80