### PR TITLE
Add integrations UI for OAuth connections

### DIFF
--- a/server/SharedFunctions.js
+++ b/server/SharedFunctions.js
@@ -76,6 +76,7 @@ export const QueueDocument = makeQueueFacade('document');
 export const QueryQueue    = makeQueueFacade('query');
 export const BrightDataQueue    = makeQueueFacade('brightdata');
 export const FlowQueue     = makeQueueFacade('flow');
+export const IntegrationQueue     = makeQueueFacade('integration');
 
 const logger = getLogger('sharedfn', "debug"); // Debug level for moduleA
 
@@ -5472,7 +5473,7 @@ export async function runPostCreateHooks(primitives, options = {}){
                 if( req?.user ){
                     payload.req = { user: { ...req.user } }
                 }
-                QueueDocument().add(`doc_refresh_${current.id}`, payload)
+               // QueueDocument().add(`doc_refresh_${current.id}`, payload)
             }catch(err){
                 console.error(`Failed to queue document refresh for ${current?.id}`, err)
             }

--- a/server/action_register.js
+++ b/server/action_register.js
@@ -1,3 +1,14 @@
 import "./actions/finance_actions"
 import "./actions/actionrunner_actions"
 import "./actions/trustpilot_helper"
+import { registerAction } from "./action_helper"
+import { getQueue } from "./queue_registry"
+
+
+registerAction("integration_sync", undefined, async (primitive, action, options, req)=>{
+    console.log(`GOT SYNC REQUEST`)
+
+    const q = await getQueue("integration")
+    await q.enqueueSync( primitive )
+
+})

--- a/server/app.js
+++ b/server/app.js
@@ -7,6 +7,7 @@ import indexRouter from './routes/index';
 import apiRouter from './routes/api';
 import publishedRouter from './routes/published';
 import authRouter from './routes/auth';
+import integrationsRouter from './routes/integrations';
 import passport from 'passport';
 import cookieSession from 'cookie-session';
 import bodyParser from 'body-parser'
@@ -388,6 +389,7 @@ app.use(
     })
   );
 
+app.use('/api/integrations', integrationsRouter);
 app.use('/api', apiRouter);
 
 app.get("/google/failed", (req, res) => {

--- a/server/bin/worker.js
+++ b/server/bin/worker.js
@@ -53,12 +53,6 @@ process.on('SIGTERM', async () => {
 
     const { SIO } = await import('../socket.js');
     const { getQueue }                 = await import('../queue_registry.js');
-    /*const { default: QueueDocument }   = await import('../document_queue.js');
-    const { default: QueueAI }         = await import('../ai_queue.js');
-    const { default: EnrichPrimitive } = await import('../enrich_queue.js');
-    const { default: QueryQueue }      = await import('../query_queue.js');
-    const { default: BrightDataQueue } = await import('../brightdata_queue.js');
-    const { default: FlowQueue }       = await import('../flow_queue.js');*/
 
     const QueueDocument = await getQueue( "document")
     const QueueAI = await getQueue( "ai")
@@ -66,6 +60,7 @@ process.on('SIGTERM', async () => {
     const QueryQueue = await getQueue( "query")
     const BrightDataQueue = await getQueue( "brightdata")
     const FlowQueue = await getQueue( "flow")
+    const IntegrationQueue = await getQueue( "integration")
 
     // Any side-effect module goes last
     await import('../action_register.js');
@@ -83,6 +78,7 @@ process.on('SIGTERM', async () => {
     BrightDataQueue.myInit();
     FlowQueue.myInit();
     QueueDocument.myInit();
+    IntegrationQueue.myInit();
 
     // Subscribe for cross-service queue control (watch/stop)
     const CONTROL_CHANNEL = 'queue:control';
@@ -176,7 +172,7 @@ process.on('SIGTERM', async () => {
     console.log('[worker] initialized, ready');
 
     // Heartbeat: log main-thread queues and request thread reports
-    const queues = [QueueDocument, QueueAI, EnrichPrimitive, QueryQueue, BrightDataQueue, FlowQueue].filter(Boolean);
+    const queues = [QueueDocument, QueueAI, EnrichPrimitive, QueryQueue, BrightDataQueue, FlowQueue, IntegrationQueue].filter(Boolean);
     const queueTypesForSweep = queues.map(inst => inst?.queueName).filter(Boolean);
 
     async function publishWaitingChildrenSweep(reason, delayMs = WAITING_CHILD_SWEEP_DELAY_MS) {

--- a/server/bin/www.js
+++ b/server/bin/www.js
@@ -19,6 +19,7 @@ import FlowQueue from '../flow_queue';
 import "../action_register"
 import { getPubSubClients } from '../redis';
 import { getQueue } from '../queue_registry';
+import IntegrationQueue from '../integration_queue';
 
 const debug = debugLib('your-project-name:server');
 
@@ -52,12 +53,13 @@ const q3 = EnrichPrimitive(); q3.myInit();
 const q4 = QueryQueue();    q4.myInit();
 const q5 = BrightDataQueue(); q5.myInit();
 const q6 = FlowQueue();     q6.myInit();
+const q7 = IntegrationQueue();     q7.myInit();
 
 const WAITING_CHILD_SWEEP_LIMIT = Number(process.env.WCHILD_SWEEP_LIMIT || 5);
 const WAITING_CHILD_SWEEP_DELAY_MS = Number(process.env.WCHILD_SWEEP_DELAY_MS || 10000);
 
 // Heartbeat: log webserver queues periodically
-const webQueues = [q1, q2, q3, q4, q5, q6].filter(Boolean);
+const webQueues = [q1, q2, q3, q4, q5, q6, q7].filter(Boolean);
 async function logWebHeartbeat() {
   try {
     console.log(`[hb-web] instance=${process.env.INSTANCE_UUID}`);

--- a/server/integration_queue.js
+++ b/server/integration_queue.js
@@ -1,0 +1,85 @@
+import BaseQueue from './base_queue';
+import { getLogger } from './logger.js';
+import { fetchPrimitive, dispatchControlUpdate } from './SharedFunctions.js';
+import { syncExternalPrimitive } from './integrations/index.js';
+
+const logger = getLogger('integration_queue', 'debug');
+
+let instance;
+
+export async function processQueue(job, cancelCheck) {
+  return IntegrationQueue().process(job, cancelCheck);
+}
+
+class IntegrationQueueClass extends BaseQueue {
+  constructor() {
+    super('integration', undefined, 2);
+  }
+
+  async enqueueSync(primitive, options = {}) {
+    const field = options.field ?? 'processing.integration.sync';
+    if (primitive.processing?.integration?.sync?.status === 'pending') {
+      logger.info(`Sync already pending for external primitive ${primitive.id}`);
+      return false;
+    }
+    const data = {
+      id: primitive.id ?? primitive._id?.toString?.(),
+      mode: 'sync',
+      field,
+      options: {
+        provider: options.provider,
+        accountId: options.accountId,
+        since: options.since,
+      },
+    };
+    await this.addJob(primitive.workspaceId, data, options.jobOptions);
+    return true;
+  }
+
+  async process(job, cancelCheck) {
+    if (job.data.mode !== 'sync') {
+      throw new Error(`Unknown integration queue mode: ${job.data.mode}`);
+    }
+    const primitiveId = job.data.id;
+    const primitive = await fetchPrimitive(primitiveId);
+    if (!primitive) {
+      throw new Error(`Primitive ${primitiveId} not found`);
+    }
+    const field = job.data.field ?? 'processing.integration.sync';
+
+    dispatchControlUpdate(primitive.id, field, {
+      status: 'running',
+      started: new Date().toISOString(),
+      track: primitive.id,
+    });
+
+    try {
+      const result = await syncExternalPrimitive(primitive, job.data.options ?? {});
+      dispatchControlUpdate(primitive.id, field, {
+        status: 'complete',
+        completed: new Date().toISOString(),
+        track: primitive.id,
+        summary: result,
+      });
+      logger.info(`External sync complete for ${primitive.id}`, result);
+      return result;
+    } catch (error) {
+      logger.error(`External sync failed for ${primitive.id}`, error);
+      dispatchControlUpdate(primitive.id, field, {
+        status: 'error',
+        error: error.message,
+        completed: new Date().toISOString(),
+        track: primitive.id,
+      });
+      throw error;
+    }
+  }
+}
+
+export default function IntegrationQueue() {
+  if (!instance) {
+    instance = new IntegrationQueueClass();
+    instance.myInit();
+  }
+  return instance;
+}

--- a/server/integrations/index.js
+++ b/server/integrations/index.js
@@ -1,0 +1,465 @@
+import { getLogger } from '../logger.js';
+import Category from '../model/Category.js';
+import IntegrationAccount from '../model/IntegrationAccount.js';
+import {
+  createPrimitive,
+  fetchPrimitive,
+} from '../SharedFunctions.js';
+
+const logger = getLogger('integrations', 'debug');
+
+const registry = new Map();
+
+const EXTERNAL_RECORD_CATEGORY_ID = Number(process.env.EXTERNAL_RECORD_CATEGORY_ID || 16000);
+
+export class IntegrationProvider {
+  constructor({ name, title, scopes = [], description } = {}) {
+    if (!name) {
+      throw new Error('IntegrationProvider requires a name');
+    }
+    this.name = name;
+    this.title = title ?? name;
+    this.scopes = scopes;
+    this.description = description;
+  }
+
+  describe() {
+    return {
+      name: this.name,
+      title: this.title,
+      scopes: this.scopes,
+      description: this.description,
+    };
+  }
+
+  getAuthorizationUrl() {
+    throw new Error('getAuthorizationUrl not implemented');
+  }
+
+  async exchangeCodeForToken() {
+    throw new Error('exchangeCodeForToken not implemented');
+  }
+
+  async refreshToken() {
+    throw new Error('refreshToken not implemented');
+  }
+
+  async ensureAccessToken(account) {
+    if (!account) {
+      throw new Error('Integration account missing');
+    }
+    if (!account.expiresAt) {
+      return account;
+    }
+    const expiresAt = new Date(account.expiresAt).getTime();
+    const now = Date.now();
+    if (Number.isFinite(expiresAt) && expiresAt - now > 60 * 1000) {
+      return account;
+    }
+    if (!account.refreshToken) {
+      return account;
+    }
+    const tokens = await this.refreshToken(account.refreshToken, account);
+    if (!tokens?.accessToken) {
+      throw new Error('Unable to refresh integration token');
+    }
+    account.accessToken = tokens.accessToken;
+    if (tokens.refreshToken) {
+      account.refreshToken = tokens.refreshToken;
+    }
+    if (tokens.expiresAt) {
+      account.expiresAt = tokens.expiresAt instanceof Date
+        ? tokens.expiresAt
+        : new Date(tokens.expiresAt);
+    } else if (tokens.expiresIn) {
+      account.expiresAt = new Date(Date.now() + Number(tokens.expiresIn) * 1000);
+    }
+    if (tokens.scope) {
+      account.scope = Array.isArray(tokens.scope) ? tokens.scope : String(tokens.scope).split(' ');
+    }
+    if (tokens.metadata) {
+      account.metadata = { ...(account.metadata ?? {}), ...tokens.metadata };
+    }
+    await account.save();
+    return account;
+  }
+
+  async fetchRecords() {
+    throw new Error('fetchRecords not implemented');
+  }
+}
+
+export function registerIntegration(provider) {
+  if (!(provider instanceof IntegrationProvider)) {
+    throw new Error('registerIntegration expects an IntegrationProvider instance');
+  }
+  registry.set(provider.name, provider);
+  logger.info(`Registered integration provider ${provider.name}`);
+  return provider;
+}
+
+export function getIntegration(name) {
+  return registry.get(name);
+}
+
+export function listIntegrations() {
+  return Array.from(registry.values()).map((provider) => provider.describe());
+}
+
+export async function ensureExternalRecordCategory() {
+  let category = await Category.findOne({ id: EXTERNAL_RECORD_CATEGORY_ID });
+  if (!category) {
+    category = await Category.create({
+      id: EXTERNAL_RECORD_CATEGORY_ID,
+      title: 'External Data Record',
+      description: 'Raw data captured from connected integrations.',
+      icon: 'CloudArrowDownIcon',
+      parameters: {
+        integrationRecord: true,
+      },
+    });
+  }
+  return category;
+}
+
+function mergeDeep(target, source) {
+  if (!source || typeof source !== 'object' || Array.isArray(source)) {
+    return target;
+  }
+  const output = target || {};
+  for (const [key, value] of Object.entries(source)) {
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      output[key] = mergeDeep(output[key] ?? {}, value);
+    } else if (value !== undefined) {
+      output[key] = value;
+    }
+  }
+  return output;
+}
+
+function setDeep(target, path, value) {
+  if (value === undefined) {
+    return;
+  }
+  const segments = Array.isArray(path) ? path : String(path).split('.');
+  let node = target;
+  for (let i = 0; i < segments.length - 1; i += 1) {
+    const seg = segments[i];
+    if (!node[seg] || typeof node[seg] !== 'object') {
+      node[seg] = {};
+    }
+    node = node[seg];
+  }
+  node[segments.at(-1)] = value;
+}
+
+function extractRecordValue(record, source) {
+  if (source === undefined || source === null) {
+    return undefined;
+  }
+  if (typeof source === 'string') {
+    if (source.startsWith('$')) {
+      switch (source) {
+        case '$recordId':
+          return record.recordId;
+        case '$uniqueValue':
+          return record.uniqueValue ?? record.externalId ?? record.recordId;
+        case '$updatedAt':
+          return record.updatedAt?.toISOString?.() ?? null;
+        case '$createdAt':
+          return record.createdAt?.toISOString?.() ?? null;
+        case '$fields':
+          return record.fields;
+        default:
+          break;
+      }
+    }
+    if (source.includes('.')) {
+      return source.split('.').reduce((acc, key) => (acc == null ? acc : acc[key]), record);
+    }
+    return record.fields?.[source];
+  }
+  if (Array.isArray(source)) {
+    return source.reduce((acc, key) => (acc == null ? acc : acc[key]), record);
+  }
+  if (typeof source === 'object') {
+    const value = extractRecordValue(record, source.path ?? source.field);
+    if ((value === undefined || value === null) && source.default !== undefined) {
+      return source.default;
+    }
+    if (source.transform === 'date' && value) {
+      return new Date(value).toISOString();
+    }
+    if (source.transform === 'number' && value !== undefined && value !== null) {
+      const num = Number(value);
+      return Number.isFinite(num) ? num : undefined;
+    }
+    if (source.transform === 'boolean' && value !== undefined && value !== null) {
+      return Boolean(value);
+    }
+    return value;
+  }
+  return source;
+}
+
+function buildRecordTitle(record, config) {
+  const candidate = extractRecordValue(record, config?.titleField);
+  if (typeof candidate === 'string' && candidate.trim()) {
+    return candidate.trim();
+  }
+  if (record.title && record.title.trim()) {
+    return record.title.trim();
+  }
+  const fallback = record.uniqueValue ?? record.externalId ?? record.recordId;
+  return `Record ${fallback}`;
+}
+
+async function buildOrUpdateChildPrimitive(recordPrim, record, mapping) {
+  const mappingKey = mapping.key ?? mapping.type;
+  if (!mapping.type || !mapping.referenceId) {
+    logger.warn('Skipping mapping without type/referenceId', { mapping });
+    return null;
+  }
+  const desiredData = {
+    workspaceId: recordPrim.workspaceId,
+    parent: recordPrim._id?.toString?.() ?? recordPrim.id,
+    paths: mapping.paths ?? ['origin'],
+    data: {
+      type: mapping.type,
+      referenceId: mapping.referenceId,
+      title: buildRecordTitle(record, mapping),
+      referenceParameters: {},
+    },
+  };
+  if (mapping.stateField) {
+    const stateValue = extractRecordValue(record, mapping.stateField);
+    if (stateValue) {
+      desiredData.data.state = stateValue;
+    }
+  }
+  if (mapping.fieldMap) {
+    for (const [targetPath, source] of Object.entries(mapping.fieldMap)) {
+      const value = extractRecordValue(record, source);
+      if (value !== undefined) {
+        setDeep(desiredData.data, targetPath, value);
+      }
+    }
+  }
+  if (mapping.staticFields) {
+    for (const [targetPath, value] of Object.entries(mapping.staticFields)) {
+      setDeep(desiredData.data, targetPath, value);
+    }
+  }
+
+  const integrationResources = recordPrim.resources?.integration ?? {};
+  integrationResources.children ??= {};
+  const existingChildId = integrationResources.children[mappingKey];
+  let childPrimitive = existingChildId ? await fetchPrimitive(existingChildId) : undefined;
+
+  if (!childPrimitive) {
+    childPrimitive = await createPrimitive(desiredData);
+  } else {
+    if (desiredData.data.title) {
+      childPrimitive.title = desiredData.data.title;
+    }
+    if (desiredData.data.state) {
+      childPrimitive.state = desiredData.data.state;
+    }
+    const updatedRefParams = mergeDeep(childPrimitive.referenceParameters ?? {}, desiredData.data.referenceParameters ?? {});
+    childPrimitive.set('referenceParameters', updatedRefParams);
+    childPrimitive.markModified('referenceParameters');
+    await childPrimitive.save();
+  }
+
+  integrationResources.children[mappingKey] = childPrimitive._id?.toString?.() ?? childPrimitive.id;
+  recordPrim.set('resources.integration', integrationResources);
+  recordPrim.markModified('resources');
+  await recordPrim.save();
+
+  return {
+    mappingKey,
+    primitiveId: integrationResources.children[mappingKey],
+  };
+}
+
+export async function syncExternalPrimitive(primitive, options = {}) {
+  const providerName = options.provider ?? primitive.referenceParameters?.provider;
+  if (!providerName) {
+    throw new Error('External primitive is missing a provider');
+  }
+  const provider = getIntegration(providerName);
+  if (!provider) {
+    throw new Error(`Integration provider '${providerName}' is not registered`);
+  }
+
+  const accountId = options.accountId
+    ?? primitive.referenceParameters?.integrationAccountId
+    ?? primitive.resources?.integration?.accountId;
+  if (!accountId) {
+    throw new Error('No integration account configured for this primitive');
+  }
+
+  const account = await IntegrationAccount.findById(accountId);
+  if (!account) {
+    throw new Error('Integration account not found');
+  }
+  if (primitive.workspaceId && account.workspaceId
+    && primitive.workspaceId.toString() !== account.workspaceId.toString()) {
+    throw new Error('Integration account does not belong to the same workspace');
+  }
+
+  await provider.ensureAccessToken(account);
+
+  const sourceConfig = {
+    ...(primitive.referenceParameters?.source ?? {}),
+    ...(options.sourceOverride ?? {}),
+  };
+  if (!sourceConfig) {
+    throw new Error('External primitive is missing source configuration');
+  }
+
+  const since = options.since
+    ?? primitive.referenceParameters?.lastSyncedAt
+    ?? primitive.resources?.integration?.lastSyncedAt;
+
+  const fetchOptions = {
+    since,
+    filters: sourceConfig.filters ?? {},
+    maxRecords: options.maxRecords ?? sourceConfig.maxRecords,
+  };
+
+  const response = await provider.fetchRecords(account, sourceConfig, fetchOptions);
+  const records = response?.items ?? [];
+
+  if (!Array.isArray(records)) {
+    throw new Error('Integration provider returned an invalid record set');
+  }
+
+  const categoryId = primitive.referenceParameters?.recordCategoryId
+    ?? (await ensureExternalRecordCategory()).id;
+  const recordPrimitiveType = primitive.referenceParameters?.recordPrimitiveType ?? 'result';
+  const recordPaths = primitive.referenceParameters?.recordPaths ?? ['origin'];
+  const mappings = Array.isArray(primitive.referenceParameters?.mappings)
+    ? primitive.referenceParameters.mappings
+    : [];
+
+  const existingState = primitive.resources?.integration ?? {};
+  const recordMap = { ...(existingState.records ?? {}) };
+
+  let created = 0;
+  let updated = 0;
+  let latestTimestamp = since ? new Date(since).getTime() : 0;
+
+  for (const record of records) {
+    const key = String(record.externalId ?? record.uniqueValue ?? record.recordId ?? '');
+    if (!key) {
+      logger.warn('Skipping record without an identifier');
+      continue;
+    }
+
+    const existing = recordMap[key];
+    let recordPrimitive;
+
+    if (existing?.primitiveId) {
+      recordPrimitive = await fetchPrimitive(existing.primitiveId);
+    }
+
+    const desiredTitle = buildRecordTitle(record, primitive.referenceParameters);
+
+    if (!recordPrimitive) {
+      recordPrimitive = await createPrimitive({
+        workspaceId: primitive.workspaceId,
+        parent: primitive._id?.toString?.() ?? primitive.id,
+        paths: recordPaths,
+        data: {
+          type: recordPrimitiveType,
+          referenceId: categoryId,
+          title: desiredTitle,
+          referenceParameters: {},
+        },
+      });
+      created += 1;
+    } else {
+      if (desiredTitle && recordPrimitive.title !== desiredTitle) {
+        recordPrimitive.title = desiredTitle;
+      }
+      updated += 1;
+    }
+
+    const referenceParameters = mergeDeep(recordPrimitive.referenceParameters ?? {}, {
+      external: {
+        provider: providerName,
+        recordId: record.recordId,
+        uniqueValue: record.uniqueValue ?? record.externalId ?? record.recordId,
+        updatedAt: record.updatedAt?.toISOString?.() ?? null,
+        createdAt: record.createdAt?.toISOString?.() ?? null,
+        fields: record.fields ?? {},
+        raw: record.raw ?? undefined,
+      },
+    });
+    recordPrimitive.set('referenceParameters', referenceParameters);
+    recordPrimitive.markModified('referenceParameters');
+    await recordPrimitive.save();
+
+    const childSummaries = [];
+    for (const mapping of mappings) {
+      try {
+        const summary = await buildOrUpdateChildPrimitive(recordPrimitive, record, mapping);
+        if (summary) {
+          childSummaries.push(summary);
+        }
+      } catch (error) {
+        logger.error(`Failed to process mapping for record ${key}`, error);
+      }
+    }
+
+    recordMap[key] = {
+      primitiveId: recordPrimitive._id?.toString?.() ?? recordPrimitive.id,
+      updatedAt: referenceParameters.external.updatedAt,
+      recordId: record.recordId,
+      uniqueValue: record.uniqueValue ?? record.externalId ?? record.recordId,
+      children: childSummaries,
+    };
+
+    if (record.updatedAt) {
+      const ts = new Date(record.updatedAt).getTime();
+      if (Number.isFinite(ts)) {
+        latestTimestamp = Math.max(latestTimestamp, ts);
+      }
+    }
+  }
+
+  const lastSyncedAt = Number.isFinite(latestTimestamp)
+    ? new Date(latestTimestamp).toISOString()
+    : new Date().toISOString();
+
+  const integrationState = {
+    ...existingState,
+    provider: providerName,
+    accountId: account._id?.toString?.() ?? account.id,
+    records: recordMap,
+    lastSyncedAt,
+    cursor: response?.cursor ?? existingState.cursor ?? null,
+    fetchedAt: new Date().toISOString(),
+  };
+
+  primitive.set('resources.integration', integrationState);
+  primitive.markModified('resources');
+  primitive.set('referenceParameters.lastSyncedAt', lastSyncedAt);
+  primitive.markModified('referenceParameters');
+  if (response?.cursor) {
+    primitive.set('referenceParameters.cursor', response.cursor);
+    primitive.markModified('referenceParameters');
+  }
+  await primitive.save();
+
+  return {
+    created,
+    updated,
+    processed: records.length,
+    lastSyncedAt,
+  };
+}
+
+// auto-register bundled providers
+import './providers/airtable.js';

--- a/server/integrations/index.js
+++ b/server/integrations/index.js
@@ -5,106 +5,18 @@ import {
   createPrimitive,
   fetchPrimitive,
 } from '../SharedFunctions.js';
+import { getIntegration as getRegisteredIntegration } from './registry.js';
+
+export {
+  IntegrationProvider,
+  registerIntegration,
+  getIntegration,
+  listIntegrations,
+} from './registry.js';
 
 const logger = getLogger('integrations', 'debug');
 
-const registry = new Map();
-
 const EXTERNAL_RECORD_CATEGORY_ID = Number(process.env.EXTERNAL_RECORD_CATEGORY_ID || 16000);
-
-export class IntegrationProvider {
-  constructor({ name, title, scopes = [], description } = {}) {
-    if (!name) {
-      throw new Error('IntegrationProvider requires a name');
-    }
-    this.name = name;
-    this.title = title ?? name;
-    this.scopes = scopes;
-    this.description = description;
-  }
-
-  describe() {
-    return {
-      name: this.name,
-      title: this.title,
-      scopes: this.scopes,
-      description: this.description,
-    };
-  }
-
-  getAuthorizationUrl() {
-    throw new Error('getAuthorizationUrl not implemented');
-  }
-
-  async exchangeCodeForToken() {
-    throw new Error('exchangeCodeForToken not implemented');
-  }
-
-  async refreshToken() {
-    throw new Error('refreshToken not implemented');
-  }
-
-  async ensureAccessToken(account) {
-    if (!account) {
-      throw new Error('Integration account missing');
-    }
-    if (!account.expiresAt) {
-      return account;
-    }
-    const expiresAt = new Date(account.expiresAt).getTime();
-    const now = Date.now();
-    if (Number.isFinite(expiresAt) && expiresAt - now > 60 * 1000) {
-      return account;
-    }
-    if (!account.refreshToken) {
-      return account;
-    }
-    const tokens = await this.refreshToken(account.refreshToken, account);
-    if (!tokens?.accessToken) {
-      throw new Error('Unable to refresh integration token');
-    }
-    account.accessToken = tokens.accessToken;
-    if (tokens.refreshToken) {
-      account.refreshToken = tokens.refreshToken;
-    }
-    if (tokens.expiresAt) {
-      account.expiresAt = tokens.expiresAt instanceof Date
-        ? tokens.expiresAt
-        : new Date(tokens.expiresAt);
-    } else if (tokens.expiresIn) {
-      account.expiresAt = new Date(Date.now() + Number(tokens.expiresIn) * 1000);
-    }
-    if (tokens.scope) {
-      account.scope = Array.isArray(tokens.scope) ? tokens.scope : String(tokens.scope).split(' ');
-    }
-    if (tokens.metadata) {
-      account.metadata = { ...(account.metadata ?? {}), ...tokens.metadata };
-    }
-    await account.save();
-    return account;
-  }
-
-  async fetchRecords() {
-    throw new Error('fetchRecords not implemented');
-  }
-}
-
-export function registerIntegration(provider) {
-  if (!(provider instanceof IntegrationProvider)) {
-    throw new Error('registerIntegration expects an IntegrationProvider instance');
-  }
-  registry.set(provider.name, provider);
-  logger.info(`Registered integration provider ${provider.name}`);
-  return provider;
-}
-
-export function getIntegration(name) {
-  return registry.get(name);
-}
-
-export function listIntegrations() {
-  return Array.from(registry.values()).map((provider) => provider.describe());
-}
 
 export async function ensureExternalRecordCategory() {
   let category = await Category.findOne({ id: EXTERNAL_RECORD_CATEGORY_ID });
@@ -287,7 +199,7 @@ export async function syncExternalPrimitive(primitive, options = {}) {
   if (!providerName) {
     throw new Error('External primitive is missing a provider');
   }
-  const provider = getIntegration(providerName);
+  const provider = getRegisteredIntegration(providerName);
   if (!provider) {
     throw new Error(`Integration provider '${providerName}' is not registered`);
   }

--- a/server/integrations/providers/airtable.js
+++ b/server/integrations/providers/airtable.js
@@ -1,0 +1,272 @@
+import { URL, URLSearchParams } from 'node:url';
+import { Buffer } from 'node:buffer';
+import { getLogger } from '../../logger.js';
+import { IntegrationProvider, registerIntegration } from '../index.js';
+
+const logger = getLogger('integration-airtable', 'debug');
+
+const AUTH_BASE = 'https://airtable.com/oauth2/v1';
+const API_BASE = 'https://api.airtable.com/v0';
+
+function getEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing environment variable ${name} for Airtable integration`);
+  }
+  return value;
+}
+
+function toIso(input) {
+  if (!input) return undefined;
+  const date = input instanceof Date ? input : new Date(input);
+  if (Number.isNaN(date.getTime())) {
+    return undefined;
+  }
+  return date.toISOString();
+}
+
+function escapeFormulaLiteral(value) {
+  if (value === undefined || value === null) {
+    return '';
+  }
+  return `'${String(value).replace(/'/g, "\\'")}'`;
+}
+
+function buildFilterFormula(config, since, filters = {}) {
+  const clauses = [];
+  const timestampField = config.timestampField || config.lastModifiedField;
+  const sinceIso = toIso(since);
+  if (timestampField && sinceIso) {
+    clauses.push(`IS_AFTER({${timestampField}}, ${escapeFormulaLiteral(sinceIso)})`);
+  }
+  const range = filters.dateRange ?? {};
+  if (timestampField && range.from) {
+    clauses.push(`IS_AFTER({${timestampField}}, ${escapeFormulaLiteral(toIso(range.from))})`);
+  }
+  if (timestampField && range.to) {
+    clauses.push(`IS_BEFORE({${timestampField}}, ${escapeFormulaLiteral(toIso(range.to))})`);
+  }
+  if (filters.formula) {
+    clauses.push(`(${filters.formula})`);
+  }
+  if (clauses.length === 0) {
+    return undefined;
+  }
+  if (clauses.length === 1) {
+    return clauses[0];
+  }
+  return `AND(${clauses.join(',')})`;
+}
+
+function normalizeRecord(record, config) {
+  const primaryField = config.primaryKeyField || config.primaryField;
+  const timestampField = config.timestampField || config.lastModifiedField;
+  const uniqueValue = primaryField ? record.fields?.[primaryField] : undefined;
+  const updatedRaw = timestampField ? record.fields?.[timestampField] : undefined;
+  const updatedAt = updatedRaw ? new Date(updatedRaw) : new Date(record.createdTime);
+  const createdAt = record.createdTime ? new Date(record.createdTime) : updatedAt;
+  const titleField = config.titleField || primaryField;
+  const title = titleField ? record.fields?.[titleField] : undefined;
+
+  return {
+    recordId: record.id,
+    externalId: uniqueValue ?? record.id,
+    uniqueValue: uniqueValue ?? record.id,
+    createdAt,
+    updatedAt,
+    title: typeof title === 'string' ? title : undefined,
+    fields: record.fields ?? {},
+    raw: record,
+  };
+}
+
+class AirtableIntegration extends IntegrationProvider {
+  constructor() {
+    super({
+      name: 'airtable',
+      title: 'Airtable',
+      scopes: ['data.records:read'],
+      description: 'Sync records from Airtable bases and tables.',
+    });
+  }
+
+  get clientId() {
+    return getEnv('AIRTABLE_CLIENT_ID');
+  }
+
+  get clientSecret() {
+    return getEnv('AIRTABLE_CLIENT_SECRET');
+  }
+
+  get defaultRedirectUri() {
+    return getEnv('AIRTABLE_OAUTH_REDIRECT');
+  }
+
+  getAuthorizationUrl({ state, redirectUri, scopes } = {}) {
+    const url = new URL(`${AUTH_BASE}/authorize`);
+    const params = new URLSearchParams({
+      client_id: this.clientId,
+      response_type: 'code',
+      redirect_uri: redirectUri || this.defaultRedirectUri,
+      scope: (scopes && scopes.length > 0 ? scopes : this.scopes).join(' '),
+      state,
+    });
+    url.search = params.toString();
+    return url.toString();
+  }
+
+  async exchangeCodeForToken({ code, redirectUri }) {
+    const params = new URLSearchParams({
+      grant_type: 'authorization_code',
+      code,
+      redirect_uri: redirectUri || this.defaultRedirectUri,
+    });
+    return this.requestToken(params);
+  }
+
+  async refreshToken(refreshToken) {
+    const params = new URLSearchParams({
+      grant_type: 'refresh_token',
+      refresh_token: refreshToken,
+    });
+    return this.requestToken(params);
+  }
+
+  async requestToken(params) {
+    const response = await fetch(`${AUTH_BASE}/token`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Basic ${Buffer.from(`${this.clientId}:${this.clientSecret}`).toString('base64')}`,
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: params,
+    });
+    if (!response.ok) {
+      const errorBody = await response.text();
+      throw new Error(`Airtable token exchange failed (${response.status}): ${errorBody}`);
+    }
+    const body = await response.json();
+    const expiresIn = body.expires_in ? Number(body.expires_in) : undefined;
+    const expiresAt = expiresIn ? new Date(Date.now() + expiresIn * 1000) : undefined;
+    return {
+      accessToken: body.access_token,
+      refreshToken: body.refresh_token,
+      expiresIn,
+      expiresAt,
+      scope: body.scope ? String(body.scope).split(' ') : undefined,
+      metadata: {
+        tokenType: body.token_type,
+      },
+    };
+  }
+
+  async fetchRecords(account, config, options = {}) {
+    if (!config?.baseId || !config?.tableId) {
+      throw new Error('Airtable configuration requires baseId and tableId');
+    }
+
+    await this.ensureAccessToken(account);
+
+    logger.debug('Fetching Airtable records', {
+      baseId: config.baseId,
+      tableId: config.tableId,
+      since: options.since,
+    });
+
+    const items = [];
+    let offset;
+    let accessToken = account.accessToken;
+    let refreshed = false;
+    const pageSize = Number(config.pageSize ?? 100);
+    const maxRecords = Number(options.maxRecords ?? config.maxRecords ?? 1000);
+
+    const formula = buildFilterFormula(config, options.since, options.filters);
+
+    const doRequest = async (url) => {
+      const response = await fetch(url, {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+      if (response.status === 401 && !refreshed && account.refreshToken) {
+        refreshed = true;
+        const tokens = await this.refreshToken(account.refreshToken);
+        if (tokens?.accessToken) {
+          account.accessToken = tokens.accessToken;
+          if (tokens.refreshToken) {
+            account.refreshToken = tokens.refreshToken;
+          }
+          if (tokens.expiresAt) {
+            account.expiresAt = tokens.expiresAt;
+          }
+          await account.save();
+          accessToken = account.accessToken;
+          return doRequest(url);
+        }
+      }
+      if (!response.ok) {
+        const errorBody = await response.text();
+        throw new Error(`Airtable API error (${response.status}): ${errorBody}`);
+      }
+      return response.json();
+    };
+
+    do {
+      const endpoint = new URL(`${API_BASE}/${config.baseId}/${encodeURIComponent(config.tableId)}`);
+      const search = endpoint.searchParams;
+      search.set('pageSize', String(pageSize));
+      if (offset) {
+        search.set('offset', offset);
+      }
+      if (formula) {
+        search.set('filterByFormula', formula);
+      }
+      if (config.viewId) {
+        search.set('view', config.viewId);
+      }
+      if (Array.isArray(config.fields)) {
+        for (const field of config.fields) {
+          search.append('fields[]', field);
+        }
+      }
+      if (Array.isArray(config.sort)) {
+        config.sort.forEach((entry, idx) => {
+          if (entry?.field) {
+            search.append(`sort[${idx}][field]`, entry.field);
+            if (entry.direction) {
+              search.append(`sort[${idx}][direction]`, entry.direction);
+            }
+          }
+        });
+      }
+
+      const payload = await doRequest(endpoint.toString());
+      const pageRecords = Array.isArray(payload.records) ? payload.records : [];
+      for (const record of pageRecords) {
+        const normalized = normalizeRecord(record, config);
+        if (options.since) {
+          const sinceDate = new Date(options.since);
+          if (normalized.updatedAt && normalized.updatedAt <= sinceDate) {
+            continue;
+          }
+        }
+        items.push(normalized);
+        if (items.length >= maxRecords) {
+          break;
+        }
+      }
+      offset = payload.offset;
+      if (items.length >= maxRecords) {
+        break;
+      }
+    } while (offset);
+
+    return {
+      items,
+      cursor: offset ? { offset } : undefined,
+    };
+  }
+}
+
+registerIntegration(new AirtableIntegration());

--- a/server/integrations/providers/airtable.js
+++ b/server/integrations/providers/airtable.js
@@ -206,7 +206,7 @@ class AirtableIntegration extends IntegrationProvider {
           account.accessToken = tokens.accessToken;
           if (tokens.refreshToken) {
             account.refreshToken = tokens.refreshToken;
-          }
+          }s
           if (tokens.expiresAt) {
             account.expiresAt = tokens.expiresAt;
           }

--- a/server/integrations/registry.js
+++ b/server/integrations/registry.js
@@ -4,7 +4,7 @@ const logger = getLogger('integrations', 'debug');
 const registry = new Map();
 
 export class IntegrationProvider {
-  constructor({ name, title, scopes = [], description, requiresPkce = false } = {}) {
+  constructor({ name, title, scopes = [], description, requiresPkce = false, supportsDiscovery = false } = {}) {
     if (!name) {
       throw new Error('IntegrationProvider requires a name');
     }
@@ -13,6 +13,7 @@ export class IntegrationProvider {
     this.scopes = scopes;
     this.description = description;
     this.requiresPkce = Boolean(requiresPkce);
+    this.supportsDiscovery = Boolean(supportsDiscovery);
   }
 
   describe() {
@@ -22,6 +23,8 @@ export class IntegrationProvider {
       scopes: this.scopes,
       description: this.description,
       requiresPkce: this.requiresPkce,
+      supportsDiscovery: this.supportsDiscovery,
+      configuration: this.describeConfiguration(),
     };
   }
 
@@ -79,6 +82,17 @@ export class IntegrationProvider {
 
   async fetchRecords() {
     throw new Error('fetchRecords not implemented');
+  }
+
+  async discover() {
+    throw new Error('discover not implemented');
+  }
+
+  describeConfiguration() {
+    return {
+      account: [],
+      primitive: [],
+    };
   }
 }
 

--- a/server/integrations/registry.js
+++ b/server/integrations/registry.js
@@ -1,0 +1,100 @@
+import { getLogger } from '../logger.js';
+
+const logger = getLogger('integrations', 'debug');
+const registry = new Map();
+
+export class IntegrationProvider {
+  constructor({ name, title, scopes = [], description, requiresPkce = false } = {}) {
+    if (!name) {
+      throw new Error('IntegrationProvider requires a name');
+    }
+    this.name = name;
+    this.title = title ?? name;
+    this.scopes = scopes;
+    this.description = description;
+    this.requiresPkce = Boolean(requiresPkce);
+  }
+
+  describe() {
+    return {
+      name: this.name,
+      title: this.title,
+      scopes: this.scopes,
+      description: this.description,
+      requiresPkce: this.requiresPkce,
+    };
+  }
+
+  getAuthorizationUrl() {
+    throw new Error('getAuthorizationUrl not implemented');
+  }
+
+  async exchangeCodeForToken() {
+    throw new Error('exchangeCodeForToken not implemented');
+  }
+
+  async refreshToken() {
+    throw new Error('refreshToken not implemented');
+  }
+
+  async ensureAccessToken(account) {
+    if (!account) {
+      throw new Error('Integration account missing');
+    }
+    if (!account.expiresAt) {
+      return account;
+    }
+    const expiresAt = new Date(account.expiresAt).getTime();
+    const now = Date.now();
+    if (Number.isFinite(expiresAt) && expiresAt - now > 60 * 1000) {
+      return account;
+    }
+    if (!account.refreshToken) {
+      return account;
+    }
+    const tokens = await this.refreshToken(account.refreshToken, account);
+    if (!tokens?.accessToken) {
+      throw new Error('Unable to refresh integration token');
+    }
+    account.accessToken = tokens.accessToken;
+    if (tokens.refreshToken) {
+      account.refreshToken = tokens.refreshToken;
+    }
+    if (tokens.expiresAt) {
+      account.expiresAt = tokens.expiresAt instanceof Date
+        ? tokens.expiresAt
+        : new Date(tokens.expiresAt);
+    } else if (tokens.expiresIn) {
+      account.expiresAt = new Date(Date.now() + Number(tokens.expiresIn) * 1000);
+    }
+    if (tokens.scope) {
+      account.scope = Array.isArray(tokens.scope) ? tokens.scope : String(tokens.scope).split(' ');
+    }
+    if (tokens.metadata) {
+      account.metadata = { ...(account.metadata ?? {}), ...tokens.metadata };
+    }
+    await account.save();
+    return account;
+  }
+
+  async fetchRecords() {
+    throw new Error('fetchRecords not implemented');
+  }
+}
+
+export function registerIntegration(provider) {
+  if (!(provider instanceof IntegrationProvider)) {
+    throw new Error('registerIntegration expects an IntegrationProvider instance');
+  }
+  registry.set(provider.name, provider);
+  logger.info(`Registered integration provider ${provider.name}`);
+  return provider;
+}
+
+export function getIntegration(name) {
+  return registry.get(name);
+}
+
+export function listIntegrations() {
+  return Array.from(registry.values()).map((provider) => provider.describe());
+}

--- a/server/integrations/state.js
+++ b/server/integrations/state.js
@@ -1,0 +1,33 @@
+import { randomBytes } from 'node:crypto';
+import { getRedisBase } from '../redis.js';
+
+const STATE_PREFIX = 'integration:state:';
+const DEFAULT_TTL_SECONDS = 10 * 60;
+
+export async function createIntegrationState(payload, ttlSeconds = DEFAULT_TTL_SECONDS) {
+  const state = randomBytes(16).toString('hex');
+  const client = getRedisBase('integration-state');
+  await client.setEx(`${STATE_PREFIX}${state}`, ttlSeconds, JSON.stringify({
+    ...payload,
+    createdAt: new Date().toISOString(),
+  }));
+  return state;
+}
+
+export async function consumeIntegrationState(state) {
+  if (!state) {
+    return null;
+  }
+  const client = getRedisBase('integration-state');
+  const key = `${STATE_PREFIX}${state}`;
+  const json = await client.get(key);
+  if (!json) {
+    return null;
+  }
+  await client.del(key);
+  try {
+    return JSON.parse(json);
+  } catch (error) {
+    return null;
+  }
+}

--- a/server/job-worker.js
+++ b/server/job-worker.js
@@ -150,6 +150,8 @@ async function getQueueObject(type) {
             return (await import('./brightdata_queue.js'))
         case 'flow':
             return (await import('./flow_queue.js'))
+        case 'integration':
+            return (await import('./integration_queue.js'))
         default:
             throw new Error(`Unknown queue type: ${type}`);
     }

--- a/server/model/IntegrationAccount.js
+++ b/server/model/IntegrationAccount.js
@@ -1,0 +1,38 @@
+import mongoose from 'mongoose';
+
+const { Schema, model } = mongoose;
+
+const integrationAccountSchema = new Schema(
+  {
+    provider: { type: String, required: true },
+    userId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+    workspaceId: { type: Schema.Types.ObjectId, ref: 'Workspace', required: true },
+    accessToken: { type: String, required: true },
+    refreshToken: { type: String },
+    expiresAt: { type: Date },
+    scope: [{ type: String }],
+    metadata: Schema.Types.Mixed,
+  },
+  {
+    timestamps: true,
+    strict: false,
+  }
+);
+
+integrationAccountSchema.methods.toSafeObject = function toSafeObject() {
+  return {
+    id: this._id.toString(),
+    provider: this.provider,
+    userId: this.userId?.toString?.() ?? this.userId,
+    workspaceId: this.workspaceId?.toString?.() ?? this.workspaceId,
+    scope: this.scope ?? [],
+    expiresAt: this.expiresAt ?? null,
+    metadata: this.metadata ?? {},
+    createdAt: this.createdAt,
+    updatedAt: this.updatedAt,
+  };
+};
+
+const IntegrationAccount = model('IntegrationAccount', integrationAccountSchema);
+
+export default IntegrationAccount;

--- a/server/queue_registry.js
+++ b/server/queue_registry.js
@@ -9,6 +9,7 @@ const loaders = {
   query:     () => import('./query_queue.js'),
   brightdata:() => import('./brightdata_queue.js'),
   flow:      () => import('./flow_queue.js'),
+  integration: () => import('./integration_queue.js'),
 };
 
 export function registerQueue(name, instance) {

--- a/server/routes/integrations.js
+++ b/server/routes/integrations.js
@@ -1,0 +1,198 @@
+import express from 'express';
+import IntegrationQueue from '../integration_queue.js';
+import IntegrationAccount from '../model/IntegrationAccount.js';
+import { fetchPrimitive } from '../SharedFunctions.js';
+import { getIntegration, listIntegrations } from '../integrations/index.js';
+import { createIntegrationState, consumeIntegrationState } from '../integrations/state.js';
+
+const router = express.Router();
+
+function ensureWorkspaceAccess(req, workspaceId) {
+  if (!workspaceId) {
+    return false;
+  }
+  const ids = (req.user?.workspaceIds ?? []).map((id) => id.toString());
+  return ids.includes(workspaceId.toString());
+}
+
+router.get('/providers', (req, res) => {
+  res.json({ providers: listIntegrations() });
+});
+
+router.get('/accounts', async (req, res) => {
+  try {
+    const { provider, workspaceId } = req.query;
+    const filter = { userId: req.user._id };
+    if (provider) {
+      filter.provider = provider;
+    }
+    if (workspaceId) {
+      if (!ensureWorkspaceAccess(req, workspaceId)) {
+        return res.status(403).json({ error: 'Forbidden' });
+      }
+      filter.workspaceId = workspaceId;
+    } else {
+      filter.workspaceId = { $in: req.user.workspaceIds ?? [] };
+    }
+    const accounts = await IntegrationAccount.find(filter).lean();
+    res.json({
+      accounts: accounts.map((account) => ({
+        id: account._id.toString(),
+        provider: account.provider,
+        workspaceId: account.workspaceId?.toString?.() ?? account.workspaceId,
+        scope: account.scope ?? [],
+        expiresAt: account.expiresAt ?? null,
+        metadata: account.metadata ?? {},
+        createdAt: account.createdAt,
+        updatedAt: account.updatedAt,
+      })),
+    });
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+router.post('/external/:id/sync', async (req, res) => {
+  try {
+    const { id } = req.params;
+    const primitive = await fetchPrimitive(id, { workspaceId: { $in: req.user.workspaceIds ?? [] } });
+    if (!primitive) {
+      return res.status(404).json({ error: 'Primitive not found' });
+    }
+    if (primitive.type !== 'external') {
+      return res.status(400).json({ error: 'Primitive is not an external integration' });
+    }
+    await IntegrationQueue().enqueueSync(primitive, {
+      provider: req.body?.provider,
+      accountId: req.body?.accountId,
+      since: req.body?.since,
+    });
+    res.json({ queued: true });
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+router.get('/:provider/oauth/start', async (req, res) => {
+  try {
+    const { provider } = req.params;
+    const integration = getIntegration(provider);
+    if (!integration) {
+      return res.status(404).json({ error: 'Unknown integration provider' });
+    }
+    const workspaceId = req.query.workspaceId ?? req.user.workspaceIds?.[0];
+    if (!workspaceId) {
+      return res.status(400).json({ error: 'workspaceId is required' });
+    }
+    if (!ensureWorkspaceAccess(req, workspaceId)) {
+      return res.status(403).json({ error: 'Forbidden' });
+    }
+    const redirectUri = req.query.redirectUri || integration.defaultRedirectUri;
+    const scopes = req.query.scopes
+      ? String(req.query.scopes).split(',').map((s) => s.trim()).filter(Boolean)
+      : undefined;
+    const state = await createIntegrationState({
+      provider,
+      userId: req.user._id,
+      workspaceId,
+      redirectUri,
+      returnTo: req.query.returnTo,
+    });
+    const authorizationUrl = integration.getAuthorizationUrl({
+      state,
+      redirectUri,
+      scopes,
+    });
+    res.json({ authorizationUrl, state });
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+router.get('/:provider/oauth/callback', async (req, res) => {
+  try {
+    const { provider } = req.params;
+    const { code, state } = req.query;
+    if (!code || !state) {
+      return res.status(400).json({ error: 'Missing code or state' });
+    }
+    const integration = getIntegration(provider);
+    if (!integration) {
+      return res.status(404).json({ error: 'Unknown integration provider' });
+    }
+    const context = await consumeIntegrationState(state);
+    if (!context || context.provider !== provider) {
+      return res.status(400).json({ error: 'Invalid or expired state parameter' });
+    }
+    if (req.user?._id && context.userId && req.user._id.toString() !== context.userId.toString()) {
+      return res.status(403).json({ error: 'Forbidden' });
+    }
+    if (!ensureWorkspaceAccess({ user: req.user }, context.workspaceId)) {
+      return res.status(403).json({ error: 'Forbidden' });
+    }
+    const tokens = await integration.exchangeCodeForToken({
+      code,
+      redirectUri: context.redirectUri,
+    });
+    const update = {
+      provider,
+      userId: context.userId,
+      workspaceId: context.workspaceId,
+      accessToken: tokens.accessToken,
+      scope: Array.isArray(tokens.scope)
+        ? tokens.scope
+        : tokens.scope
+          ? String(tokens.scope).split(' ')
+          : integration.scopes,
+    };
+    if (tokens.refreshToken) {
+      update.refreshToken = tokens.refreshToken;
+    }
+    if (tokens.expiresAt) {
+      update.expiresAt = tokens.expiresAt;
+    } else if (tokens.expiresIn) {
+      update.expiresAt = new Date(Date.now() + Number(tokens.expiresIn) * 1000);
+    }
+    if (tokens.metadata) {
+      update.metadata = tokens.metadata;
+    }
+    const account = await IntegrationAccount.findOneAndUpdate(
+      { provider, userId: context.userId, workspaceId: context.workspaceId },
+      { $set: update },
+      { new: true, upsert: true, setDefaultsOnInsert: true },
+    );
+    const payload = {
+      success: true,
+      provider,
+      account: account.toSafeObject ? account.toSafeObject() : {
+        id: account._id.toString(),
+        provider: account.provider,
+        workspaceId: account.workspaceId?.toString?.() ?? account.workspaceId,
+        scope: account.scope ?? [],
+        expiresAt: account.expiresAt ?? null,
+        metadata: account.metadata ?? {},
+        createdAt: account.createdAt,
+        updatedAt: account.updatedAt,
+      },
+    };
+    if (context.returnTo) {
+      try {
+        const redirectUrl = new URL(context.returnTo);
+        redirectUrl.searchParams.set('integration', provider);
+        redirectUrl.searchParams.set('status', 'success');
+        redirectUrl.searchParams.set('accountId', payload.account.id);
+        return res.redirect(redirectUrl.toString());
+      } catch (err) {
+        // fall through to JSON response if redirect fails
+      }
+    }
+    res.json(payload);
+  } catch (error) {
+    if (req.query?.state) {
+      try { await consumeIntegrationState(req.query.state); } catch (_) { /* noop */ }
+    }
+    res.status(500).json({ error: error.message });
+  }
+});
+
+export default router;

--- a/ui/src/AccountScreen.js
+++ b/ui/src/AccountScreen.js
@@ -170,6 +170,8 @@ export default function AccountScreen(props){
                     <CheckoutButton priceId={mainstore.activeOrganization?.validPlans.find(d=>d._id === localActivePlanId)?.stripe?.priceId} isDisabled={localActivePlanId === mainstore.activeOrganization.activePlanId} size="sm"/>
                     {mainstore.activeOrganization.billing?.stripe?.subscriptionId &&  <BillingPortalButton/>}
                     <Divider className="col-span-3 my-3"/>
+                    <Button onPress={()=>navigate("/integrations")}>Integrations</Button>
+                    <Divider className="col-span-3 my-3"/>
                     <p className="text-small text-default-500">Users</p>
                     <div className="">
                         <Input

--- a/ui/src/App.js
+++ b/ui/src/App.js
@@ -31,6 +31,7 @@ import { PrimitivePopup } from './PrimitivePopup.js';
 import ResetPasswordPage from './ResetPassword.js';
 import ProjectScreen from './ProjectScreen.js';
 import UsageScreen from './UsageScreen.js';
+import IntegrationsScreen from './IntegrationsScreen.jsx';
 import { QueuePage } from './QueuePage.jsx';
 import AccountScreen from './AccountScreen.js';
 
@@ -196,6 +197,7 @@ function App() {
                 </SideNav>}>
                   <Route path="/workflow/:id/new_instance" element={<FlowInstancePage />}/>
                   <Route path="/usage/" element={<UsageScreen />}/>
+                  <Route path="/integrations" element={<IntegrationsScreen />}/>
                   <Route path="/account/" element={<AccountScreen/>}/>
                   <Route path="/queue/:id?" element={<QueuePage />}/>
                   <Route path="/workflows/:id?" element={<WorkflowDashboard widePage={widePage} setWidePage={setWidePage}/>}/>

--- a/ui/src/BoardViewer.js
+++ b/ui/src/BoardViewer.js
@@ -358,7 +358,8 @@ function SharedRenderView(d, primitive, myState, stageOptions = {}) {
             view.underlying ? ` (${primitiveToRender.plainId})` : ""
           }`;
 
-    const canvasMargin = view.inPage ? [0, 0, 0, 0] : (view.noTitle || view.inFlow) ? [0, 0, 0, 0] : [10, 10, 10, 10];
+    //const canvasMargin = view.inPage ? [0, 0, 0, 0] : (view.noTitle || view.inFlow) ? [0, 0, 0, 0] : [10, 10, 10, 10];
+    const canvasMargin = view.inPage ? [0, 0, 0, 0] :  [10, 10, 10, 10];
   
     // Optional indicator builder
     const indicators = undefined//view.primitive.flowElement ? () => buildIndicators(primitiveToRender, undefined, undefined, myState) : undefined;
@@ -1038,6 +1039,15 @@ function SharedRenderView(d, primitive, myState, stageOptions = {}) {
                 widgetConfig.content = `**${useQuery ? "Query" : "Prompt"}:** ` + (useQuery ? primitiveToPrepare.getConfig.query?.slice(0,900) : primitiveToPrepare.getConfig.prompt?.slice(0,900))
                 myState[stateId].widgetConfig = widgetConfig
                 didChange = true
+            }else if( primitiveToPrepare.type=== "external"){
+
+                widgetConfig.showItems = showItems
+                widgetConfig.title = basePrimitive.title
+                widgetConfig.icon = <HeroIcon icon='FARobot'/>
+                widgetConfig.items = "results"
+                widgetConfig.content = `**Result:** ` + (primitiveToPrepare.getConfig.result ?? "")
+                myState[stateId].widgetConfig = widgetConfig
+                didChange = true
             }else if( primitiveToPrepare.type=== "action"){
 
                 widgetConfig.showItems = showItems
@@ -1341,7 +1351,7 @@ function SharedRenderView(d, primitive, myState, stageOptions = {}) {
                     }
                 }
             }
-        }else if( renderType === "result" || renderType === "summary" || renderType === "element" || renderType === "action"){
+        }else if( renderType === "result" || renderType === "summary" || renderType === "element" || renderType === "action" || renderType === "external"){
             let viewConfig
             const viewConfigs = CollectionUtils.viewConfigs(basePrimitive.metadata)
             if( forceViewConfig ){
@@ -1570,6 +1580,7 @@ export default function BoardViewer({primitive,...props}){
         }
 
         appendUnique(allCategories.filter(category=>category.primitiveType === "search"))
+        appendUnique(allCategories.filter(category=>category.primitiveType === "external"))
 
         if( addToFlow ){
             appendUnique([categoryById[81], categoryById[113]].filter(Boolean))
@@ -1908,6 +1919,7 @@ export default function BoardViewer({primitive,...props}){
                         ...primitive.primitives.allUniqueQuery,
                         ...primitive.primitives.allUniqueSearch,
                         ...primitive.primitives.allUniqueFlow,
+                        ...primitive.primitives.allUniqueExternal,
                         ...primitive.primitives.allUniqueAction].filter(Boolean)
         
         for(const d of boards){
@@ -3242,7 +3254,7 @@ export default function BoardViewer({primitive,...props}){
                         </div>
                     }
             </div>}
-            <div className="flex relative w-full h-full @container rounded-lg shadow overflow-clip" onDrop={handleDropNewPrimitive} onDragOver={(e)=>e.preventDefault()}>
+            <div className="flex relative w-full border h-full @container rounded-lg shadow overflow-clip" onDrop={handleDropNewPrimitive} onDragOver={(e)=>e.preventDefault()}>
                 {!dockPaneInfo && <div key='chatbar' className={clsx([
                     'absolute bg-white border border-gray-200 bottom-4 space-y-2 flex flex-col left-4 overflow-hidden p-3 place-items-start rounded-md shadow-lg text-sm z-50 ',
                     agentStatus.activeChat ? 'max-h-[80vh] w-[40vw] 4xl:max-w-3xl min-w-[24rem]' : "w-96 max-h-[80vh]"
@@ -3290,14 +3302,15 @@ export default function BoardViewer({primitive,...props}){
                     {myState.activePin && <DropdownButton noBorder icon={<HeroIcon icon='FALinkBreak' className='w-5 h-5'/>} onClick={disconnectActivePin} flat placement='left-start' />}
                     {myState.createFromActivePin && <DropdownButton noBorder icon={<HeroIcon icon='FAAddChildNode' className='w-5 h-5'/>} onClick={createElementFromActivePin} flat placement='left-start' />}
                 </div>}
-                <div className={`w-full flex min-h-[40vh] h-full rounded-md`} style={{background:"#fdfdfd"}}>
+                <div className={`w-full flex min-h-[40vh] h-full rounded-md`} style={{background:"#f2f2f4"}}>
                     <InfiniteCanvas 
                                     primitive={primitive}
                                     board
-                                    background="#fdfdfd"
+                                    background="#f2f2f4"
                                     ref={setCanvasRef}
                                     ignoreAfterDrag={true}
                                     highlights={{
+                                        "frame": "glow",
                                         "primitive":"border",
                                         "cell":"background",
                                         "pin":"background",

--- a/ui/src/IntegrationsScreen.jsx
+++ b/ui/src/IntegrationsScreen.jsx
@@ -1,0 +1,283 @@
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { Button, Card, CardBody, CardHeader, Chip, Divider, Spinner } from "@heroui/react";
+import toast from "react-hot-toast";
+import MainStore from "./MainStore";
+
+function formatDate(value) {
+  if (!value) {
+    return null;
+  }
+  try {
+    const date = value instanceof Date ? value : new Date(value);
+    if (Number.isNaN(date.getTime())) {
+      return null;
+    }
+    return date.toLocaleString();
+  } catch (error) {
+    return null;
+  }
+}
+
+export default function IntegrationsScreen() {
+  const mainstore = MainStore();
+  const [providers, setProviders] = useState([]);
+  const [accounts, setAccounts] = useState([]);
+  const [loadingProviders, setLoadingProviders] = useState(false);
+  const [loadingAccounts, setLoadingAccounts] = useState(false);
+  const [startingProvider, setStartingProvider] = useState(null);
+  const [pendingResult, setPendingResult] = useState(null);
+
+  const workspaceId = mainstore.activeWorkspaceId;
+  const workspace = workspaceId ? mainstore.workspace(workspaceId) : null;
+
+  const accountsByProvider = useMemo(() => {
+    const grouped = new Map();
+    for (const account of accounts) {
+      if (!account?.provider) continue;
+      if (!grouped.has(account.provider)) {
+        grouped.set(account.provider, []);
+      }
+      grouped.get(account.provider).push(account);
+    }
+    return grouped;
+  }, [accounts]);
+
+  const loadProviders = useCallback(async () => {
+    setLoadingProviders(true);
+    try {
+      const response = await fetch("/api/integrations/providers");
+      if (!response.ok) {
+        throw new Error(`Failed to fetch providers (${response.status})`);
+      }
+      const body = await response.json();
+      setProviders(Array.isArray(body?.providers) ? body.providers : []);
+    } catch (error) {
+      console.error(error);
+      toast.error(error.message || "Unable to load integration providers");
+    } finally {
+      setLoadingProviders(false);
+    }
+  }, []);
+
+  const loadAccounts = useCallback(async () => {
+    setLoadingAccounts(true);
+    try {
+      const search = new URLSearchParams();
+      if (workspaceId) {
+        search.set("workspaceId", workspaceId);
+      }
+      const response = await fetch(`/api/integrations/accounts${search.size ? `?${search.toString()}` : ""}`);
+      if (!response.ok) {
+        throw new Error(`Failed to fetch accounts (${response.status})`);
+      }
+      const body = await response.json();
+      setAccounts(Array.isArray(body?.accounts) ? body.accounts : []);
+    } catch (error) {
+      console.error(error);
+      toast.error(error.message || "Unable to load integration accounts");
+    } finally {
+      setLoadingAccounts(false);
+    }
+  }, [workspaceId]);
+
+  useEffect(() => {
+    loadProviders();
+  }, [loadProviders]);
+
+  useEffect(() => {
+    loadAccounts();
+  }, [loadAccounts]);
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    if (params.has("status") || params.has("integration") || params.has("accountId")) {
+      setPendingResult({
+        status: params.get("status"),
+        provider: params.get("integration"),
+        accountId: params.get("accountId"),
+      });
+      params.delete("status");
+      params.delete("integration");
+      params.delete("accountId");
+      const next = params.toString();
+      const nextUrl = `${window.location.pathname}${next ? `?${next}` : ""}${window.location.hash ?? ""}`;
+      window.history.replaceState({}, document.title, nextUrl);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!pendingResult) {
+      return;
+    }
+    if (pendingResult.status === "success") {
+      const providerInfo = providers.find((entry) => entry.name === pendingResult.provider);
+      const label = providerInfo?.title || providerInfo?.name || pendingResult.provider;
+      toast.success(`Connected to ${label || "integration"}`);
+      loadAccounts();
+    } else if (pendingResult.status && pendingResult.status !== "success") {
+      toast.error("Integration authorization failed");
+    }
+    setPendingResult(null);
+  }, [pendingResult, providers, loadAccounts]);
+
+  const startOAuth = useCallback(async (providerName) => {
+    if (!providerName) {
+      return;
+    }
+    if (!workspaceId) {
+      toast.error("Select a workspace before connecting an integration");
+      return;
+    }
+    setStartingProvider(providerName);
+    try {
+      const params = new URLSearchParams({ workspaceId });
+      const returnUrl = new URL(window.location.origin);
+      returnUrl.pathname = "/integrations";
+      returnUrl.search = "";
+      returnUrl.hash = "";
+      params.set("returnTo", returnUrl.toString());
+      const response = await fetch(`/api/integrations/${providerName}/oauth/start?${params.toString()}`);
+      if (!response.ok) {
+        throw new Error(`Failed to start authorization (${response.status})`);
+      }
+      const body = await response.json();
+      if (!body?.authorizationUrl) {
+        throw new Error("Missing authorization URL");
+      }
+      window.location.href = body.authorizationUrl;
+    } catch (error) {
+      console.error(error);
+      toast.error(error.message || "Unable to start authorization");
+      setStartingProvider(null);
+    }
+  }, [workspaceId]);
+
+  const renderProviderCard = (provider) => {
+    const providerAccounts = accountsByProvider.get(provider.name) ?? [];
+    const hasAccounts = providerAccounts.length > 0;
+
+    return (
+      <Card key={provider.name} shadow="sm" className="border border-default-200">
+        <CardHeader className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h2 className="text-large font-semibold text-foreground">{provider.title || provider.name}</h2>
+            {provider.description && (
+              <p className="mt-1 text-small text-default-500">{provider.description}</p>
+            )}
+            {provider.scopes?.length > 0 && (
+              <div className="mt-3 flex flex-wrap gap-2">
+                {provider.scopes.map((scope) => (
+                  <Chip key={scope} size="sm" variant="flat" color="secondary">
+                    {scope}
+                  </Chip>
+                ))}
+              </div>
+            )}
+          </div>
+          <Button
+            color="primary"
+            radius="full"
+            onPress={() => startOAuth(provider.name)}
+            isLoading={startingProvider === provider.name}
+          >
+            {hasAccounts ? "Connect another account" : "Connect"}
+          </Button>
+        </CardHeader>
+        <CardBody className="space-y-4">
+          {loadingAccounts && providerAccounts.length === 0 ? (
+            <div className="flex items-center gap-2 text-small text-default-500">
+              <Spinner size="sm" />
+              <span>Loading connections…</span>
+            </div>
+          ) : hasAccounts ? (
+            <div className="space-y-3">
+              {providerAccounts.map((account) => (
+                <div
+                  key={account.id}
+                  className="rounded-large border border-default-200 bg-default-100/50 p-4"
+                >
+                  <div className="flex flex-col gap-1 text-small">
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                      <span className="font-medium text-foreground">Authorized account</span>
+                      {account.expiresAt && (
+                        <Chip size="sm" variant="flat" color="success">
+                          Refreshes {formatDate(account.expiresAt)}
+                        </Chip>
+                      )}
+                    </div>
+                    <div className="text-default-500">
+                      Connected {formatDate(account.createdAt) || "recently"}
+                    </div>
+                    {account.scope?.length > 0 && (
+                      <div className="text-default-500">
+                        Scope: {account.scope.join(", ")}
+                      </div>
+                    )}
+                    {account.metadata && Object.keys(account.metadata).length > 0 && (
+                      <div className="text-default-500">
+                        {Object.entries(account.metadata).map(([key, value]) => (
+                          <div key={key}>
+                            <span className="font-medium capitalize">{key}:</span> {String(value)}
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                    <div className="text-default-400">
+                      Updated {formatDate(account.updatedAt) || formatDate(account.createdAt) || "recently"}
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="text-small text-default-500">
+              No accounts connected yet. Use the Connect button to authorize access.
+            </p>
+          )}
+        </CardBody>
+      </Card>
+    );
+  };
+
+  return (
+    <div className="flex h-full w-full justify-center overflow-y-auto bg-content1">
+      <div className="flex w-full max-w-4xl flex-col gap-6 p-6">
+        <header className="flex flex-col gap-2">
+          <h1 className="text-2xl font-semibold text-foreground">Integrations</h1>
+          <p className="text-small text-default-500">
+            Connect external data sources to sync records into your workspace.
+          </p>
+          {workspace && (
+            <p className="text-small text-default-400">
+              Managing connections for <span className="font-medium text-default-500">{workspace.title}</span>
+            </p>
+          )}
+          {!workspaceId && (
+            <Chip color="warning" variant="flat" size="sm" className="w-fit">
+              Select a workspace to enable connections
+            </Chip>
+          )}
+        </header>
+
+        <Divider />
+
+        {loadingProviders && providers.length === 0 ? (
+          <div className="flex items-center gap-2 text-small text-default-500">
+            <Spinner size="sm" />
+            <span>Loading providers…</span>
+          </div>
+        ) : providers.length > 0 ? (
+          providers.map((provider) => renderProviderCard(provider))
+        ) : (
+          <Card className="border border-default-200" shadow="sm">
+            <CardBody>
+              <p className="text-small text-default-500">
+                No integrations are currently available. Check back soon for new connection options.
+              </p>
+            </CardBody>
+          </Card>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/ui/src/PrimitiveConfig.js
+++ b/ui/src/PrimitiveConfig.js
@@ -329,6 +329,10 @@ const PrimitiveConfig = {
             needCategory:false,
             defaultTitle: false
         },
+        "external": {
+            needCategory:false,
+            defaultTitle:false,
+        },
     },
     types: ["hypothesis", 
         "learning",
@@ -361,7 +365,8 @@ const PrimitiveConfig = {
         "categorizer",
         "action",
         "page",
-        "chat"
+        "chat",
+        "external"
     ],
     pageview:{
         "board":{

--- a/ui/src/RenderHelpers.js
+++ b/ui/src/RenderHelpers.js
@@ -5304,7 +5304,7 @@ function renderProcessingState({ group, x, y, width, height, spacerY, theme, id,
                 });
                 g.add(outline);
 
-                if (true || isPending) {
+                if (isPending) {
                     renderProcessingState({
                         group: g,
                         x,
@@ -5653,6 +5653,7 @@ registerRenderer( {type: "type", id: "summary", configs: "widget"}, (primitive,o
 registerRenderer( {type: "type", id: "categorizer", configs: "widget"}, (primitive,options)=>renderDefaultActionPrimitive(primitive, {...options, contentAsMarkdown: true,typeText: "Action", typeIcon: <HeroIcon icon='FARun'/>}))
 registerRenderer( {type: "type", id: "query", configs: "widget"}, (primitive,options)=>renderDefaultActionPrimitive(primitive, {...options, contentAsMarkdown: true, typeText: "Query", typeIcon: <HeroIcon icon='FARobot'/>}))
 registerRenderer( {type: "type", id: "action", configs: "widget"}, (primitive,options)=>renderDefaultActionPrimitive(primitive, {...options, contentAsMarkdown: true, typeText: "Action", typeIcon: <HeroIcon icon='FARobot'/>}))
+registerRenderer( {type: "type", id: "external", configs: "widget"}, (primitive,options)=>renderDefaultActionPrimitive(primitive, {...options, contentAsMarkdown: true, typeText: "External", typeIcon: <HeroIcon icon='FAPlug'/>}))
 registerRenderer( {type: "type", id: "search", configs: "default"}, renderDefaultActionPrimitive)
 
 function renderDefaultActionPrimitive(primitive, options){

--- a/ui/src/SideNav.js
+++ b/ui/src/SideNav.js
@@ -44,6 +44,7 @@ const navigation = [
   { name: 'Home', onClick: ()=>{navigate('/')}, icon: HomeIcon, current: urlPath === "" || urlPath === "/" },
   mainstore.activeWorkspaceId && !mainstore.activeUser.info.external && { name: 'Project Home', onClick: ()=>{navigate(`/project/${mainstore.activeWorkspaceId}`)}, icon: SparklesIcon, current: urlPath.includes("/project")},
   { name: 'Workflows', onClick: ()=>{navigate(mainstore.activeWorkspaceId ?  `/workflows/${mainstore.activeWorkspaceId}` : undefined)}, icon: SparklesIcon, current: urlPath.includes("/workflows")},
+  { name: 'Integrations', onClick: ()=>{navigate('/integrations')}, icon: Bars4Icon, current: urlPath.includes("/integrations")},
   { name: 'Usage', onClick: ()=>{navigate('/usage')}, icon: ArrowDownTrayIcon, current: urlPath.includes("/usage") },
 ].filter(Boolean)
 

--- a/ui/src/integrations/AirtableConfigurator.jsx
+++ b/ui/src/integrations/AirtableConfigurator.jsx
@@ -1,0 +1,260 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Button, Divider, Select, SelectItem, Spinner } from '@heroui/react';
+import toast from 'react-hot-toast';
+
+function mergeUnique(items) {
+  const map = new Map();
+  for (const item of items) {
+    if (!item?.id) continue;
+    if (!map.has(item.id)) {
+      map.set(item.id, item);
+    }
+  }
+  return Array.from(map.values());
+}
+
+export default function AirtableConfigurator({ account, saving, onSubmit, onCancel }) {
+  const [bases, setBases] = useState([]);
+  const [tables, setTables] = useState([]);
+  const [loadingBases, setLoadingBases] = useState(false);
+  const [loadingTables, setLoadingTables] = useState(false);
+
+  const initialConfig = useMemo(() => account?.metadata?.airtable ?? {}, [account?.metadata?.airtable]);
+
+  const [selectedBase, setSelectedBase] = useState(initialConfig.baseId ?? '');
+  const [selectedTable, setSelectedTable] = useState(initialConfig.tableId ?? '');
+
+  const fetchAllBases = useCallback(async () => {
+    if (!account?.id) {
+      return;
+    }
+    setLoadingBases(true);
+    try {
+      const collected = [];
+      let cursor;
+      do {
+        const params = new URLSearchParams({
+          accountId: account.id,
+          type: 'bases',
+        });
+        if (cursor) {
+          params.set('cursor', cursor);
+        }
+        const response = await fetch(`/api/integrations/airtable/discovery?${params.toString()}`);
+        if (!response.ok) {
+          const body = await response.json().catch(() => ({}));
+          throw new Error(body?.error || `Failed to load bases (${response.status})`);
+        }
+        const body = await response.json();
+        collected.push(...(body?.items ?? []));
+        cursor = body?.cursor ?? null;
+      } while (cursor);
+      setBases(mergeUnique(collected));
+    } catch (error) {
+      console.error(error);
+      toast.error(error.message || 'Unable to load bases');
+      setBases([]);
+    } finally {
+      setLoadingBases(false);
+    }
+  }, [account?.id]);
+
+  const fetchTablesForBase = useCallback(async (baseId) => {
+    if (!account?.id || !baseId) {
+      setTables([]);
+      return;
+    }
+    setLoadingTables(true);
+    try {
+      const collected = [];
+      let cursor;
+      do {
+        const params = new URLSearchParams({
+          accountId: account.id,
+          type: 'tables',
+          baseId,
+        });
+        if (cursor) {
+          params.set('cursor', cursor);
+        }
+        const response = await fetch(`/api/integrations/airtable/discovery?${params.toString()}`);
+        if (!response.ok) {
+          const body = await response.json().catch(() => ({}));
+          throw new Error(body?.error || `Failed to load tables (${response.status})`);
+        }
+        const body = await response.json();
+        collected.push(...(body?.items ?? []));
+        cursor = body?.cursor ?? null;
+      } while (cursor);
+      setTables(mergeUnique(collected));
+    } catch (error) {
+      console.error(error);
+      toast.error(error.message || 'Unable to load tables');
+      setTables([]);
+    } finally {
+      setLoadingTables(false);
+    }
+  }, [account?.id]);
+
+  useEffect(() => {
+    setSelectedBase(initialConfig.baseId ?? '');
+    setSelectedTable(initialConfig.tableId ?? '');
+  }, [initialConfig.baseId, initialConfig.tableId]);
+
+  useEffect(() => {
+    if (account?.id) {
+      fetchAllBases();
+    }
+  }, [account?.id, fetchAllBases]);
+
+  useEffect(() => {
+    if (selectedBase) {
+      fetchTablesForBase(selectedBase);
+    } else {
+      setTables([]);
+      setSelectedTable('');
+    }
+  }, [selectedBase, fetchTablesForBase]);
+
+  useEffect(() => {
+    if (!selectedBase && bases.length > 0 && initialConfig.baseId) {
+      const exists = bases.some((base) => base.id === initialConfig.baseId);
+      if (!exists) {
+        setBases((prev) => mergeUnique([...prev, {
+          id: initialConfig.baseId,
+          name: initialConfig.baseName || initialConfig.baseId,
+        }]));
+      }
+      setSelectedBase(initialConfig.baseId);
+    }
+  }, [bases, initialConfig.baseId, initialConfig.baseName, selectedBase]);
+
+  useEffect(() => {
+    if (!selectedTable && tables.length > 0 && initialConfig.tableId && initialConfig.baseId === selectedBase) {
+      const exists = tables.some((table) => table.id === initialConfig.tableId);
+      if (!exists) {
+        setTables((prev) => mergeUnique([...prev, {
+          id: initialConfig.tableId,
+          name: initialConfig.tableName || initialConfig.tableId,
+          fields: initialConfig.fields || [],
+        }]));
+      }
+      setSelectedTable(initialConfig.tableId);
+    }
+  }, [tables, initialConfig.tableId, initialConfig.tableName, initialConfig.fields, initialConfig.baseId, selectedBase, selectedTable]);
+
+  const selectedBaseInfo = useMemo(
+    () => bases.find((base) => base.id === selectedBase),
+    [bases, selectedBase],
+  );
+
+  const selectedTableInfo = useMemo(
+    () => tables.find((table) => table.id === selectedTable),
+    [tables, selectedTable],
+  );
+
+  const handleSubmit = () => {
+    if (!selectedBase || !selectedTable) {
+      toast.error('Select both a base and table');
+      return;
+    }
+    onSubmit?.({
+      baseId: selectedBase,
+      baseName: selectedBaseInfo?.name ?? selectedBase,
+      tableId: selectedTable,
+      tableName: selectedTableInfo?.name ?? selectedTable,
+      fields: selectedTableInfo?.fields ?? [],
+    });
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <p className="text-sm text-default-500">
+          Select the Airtable base and table you want to sync. We&apos;ll store these in your connection so future external primitives can reference them without copying IDs from URLs.
+        </p>
+      </div>
+      <div className="space-y-4">
+        <div className="flex flex-col gap-2">
+          <label className="text-sm font-medium text-default-600">Base</label>
+          <Select
+            variant="bordered"
+            selectedKeys={selectedBase ? [selectedBase] : []}
+            onChange={(event) => {
+              const value = event.target.value;
+              setSelectedBase(value);
+              setSelectedTable('');
+            }}
+            placeholder={loadingBases ? 'Loading bases…' : 'Select a base'}
+            isDisabled={loadingBases}
+          >
+            {bases.map((base) => (
+              <SelectItem key={base.id} textValue={base.name ?? base.id}>
+                {base.name ?? base.id}
+              </SelectItem>
+            ))}
+          </Select>
+          {loadingBases && (
+            <div className="flex items-center gap-2 text-sm text-default-400">
+              <Spinner size="sm" />
+              <span>Loading bases…</span>
+            </div>
+          )}
+        </div>
+        <div className="flex flex-col gap-2">
+          <label className="text-sm font-medium text-default-600">Table</label>
+          <Select
+            variant="bordered"
+            selectedKeys={selectedTable ? [selectedTable] : []}
+            onChange={(event) => setSelectedTable(event.target.value)}
+            placeholder={selectedBase ? (loadingTables ? 'Loading tables…' : 'Select a table') : 'Select a base first'}
+            isDisabled={!selectedBase || loadingTables}
+          >
+            {tables.map((table) => (
+              <SelectItem key={table.id} textValue={table.name ?? table.id}>
+                {table.name ?? table.id}
+              </SelectItem>
+            ))}
+          </Select>
+          {loadingTables && (
+            <div className="flex items-center gap-2 text-sm text-default-400">
+              <Spinner size="sm" />
+              <span>Loading tables…</span>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {selectedTableInfo?.fields?.length > 0 && (
+        <div className="space-y-2">
+          <Divider />
+          <p className="text-sm font-medium text-default-600">Fields</p>
+          <div className="flex flex-wrap gap-2 text-xs text-default-500">
+            {selectedTableInfo.fields.map((field) => (
+              <span
+                key={field.id}
+                className="rounded-full border border-default-200 px-2 py-1"
+              >
+                {field.name} · {field.type}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <div className="mt-4 flex items-center justify-end gap-2">
+        <Button variant="flat" onPress={onCancel} isDisabled={saving}>
+          Cancel
+        </Button>
+        <Button
+          color="primary"
+          onPress={handleSubmit}
+          isDisabled={!selectedBase || !selectedTable || saving}
+          isLoading={saving}
+        >
+          Save
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/integrations/AirtablePrimitiveConfigurator.jsx
+++ b/ui/src/integrations/AirtablePrimitiveConfigurator.jsx
@@ -1,0 +1,338 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Button, Divider, Select, SelectItem, Spinner } from '@heroui/react';
+import toast from 'react-hot-toast';
+
+function mergeUnique(items) {
+  const map = new Map();
+  for (const item of items) {
+    if (!item?.id) continue;
+    const existing = map.get(item.id) || {};
+    map.set(item.id, { ...existing, ...item });
+  }
+  return Array.from(map.values());
+}
+
+export default function AirtablePrimitiveConfigurator({ primitive, accountId, onFieldsPreview }) {
+  const [loadingBases, setLoadingBases] = useState(false);
+  const [loadingTables, setLoadingTables] = useState(false);
+  const [bases, setBases] = useState([]);
+  const [tables, setTables] = useState([]);
+  const [saving, setSaving] = useState(false);
+
+  const initialConfig = useMemo(() => {
+    const source = primitive?.referenceParameters?.source ?? {};
+    return {
+      baseId: source.baseId ?? primitive?.referenceParameters?.baseId,
+      baseName: source.baseName ?? primitive?.referenceParameters?.baseName,
+      tableId: source.tableId ?? primitive?.referenceParameters?.tableId,
+      tableName: source.tableName ?? primitive?.referenceParameters?.tableName,
+    };
+  }, [
+    primitive?.referenceParameters?.baseId,
+    primitive?.referenceParameters?.baseName,
+    primitive?.referenceParameters?.source,
+    primitive?.referenceParameters?.tableId,
+    primitive?.referenceParameters?.tableName,
+  ]);
+
+  const [selectedBase, setSelectedBase] = useState(initialConfig.baseId ?? '');
+  const [selectedTable, setSelectedTable] = useState(initialConfig.tableId ?? '');
+
+  const fetchBases = useCallback(async () => {
+    if (!accountId) {
+      setBases([]);
+      return;
+    }
+    setLoadingBases(true);
+    try {
+      const collected = [];
+      let cursor;
+      do {
+        const params = new URLSearchParams({ accountId, type: 'bases' });
+        if (cursor) {
+          params.set('cursor', cursor);
+        }
+        const response = await fetch(`/api/integrations/airtable/discovery?${params.toString()}`);
+        if (!response.ok) {
+          const body = await response.json().catch(() => ({}));
+          throw new Error(body?.error || `Failed to load bases (${response.status})`);
+        }
+        const body = await response.json();
+        collected.push(...(body?.items ?? []));
+        cursor = body?.cursor ?? null;
+      } while (cursor);
+      setBases(mergeUnique(collected));
+    } catch (error) {
+      console.error(error);
+      toast.error(error.message || 'Unable to load bases');
+      setBases([]);
+    } finally {
+      setLoadingBases(false);
+    }
+  }, [accountId]);
+
+  const fetchTables = useCallback(async (baseId) => {
+    if (!accountId || !baseId) {
+      setTables([]);
+      return;
+    }
+    setLoadingTables(true);
+    try {
+      const collected = [];
+      let cursor;
+      do {
+        const params = new URLSearchParams({ accountId, type: 'tables', baseId });
+        if (cursor) {
+          params.set('cursor', cursor);
+        }
+        const response = await fetch(`/api/integrations/airtable/discovery?${params.toString()}`);
+        if (!response.ok) {
+          const body = await response.json().catch(() => ({}));
+          throw new Error(body?.error || `Failed to load tables (${response.status})`);
+        }
+        const body = await response.json();
+        collected.push(...(body?.items ?? []));
+        cursor = body?.cursor ?? null;
+      } while (cursor);
+      setTables(mergeUnique(collected));
+    } catch (error) {
+      console.error(error);
+      toast.error(error.message || 'Unable to load tables');
+      setTables([]);
+    } finally {
+      setLoadingTables(false);
+    }
+  }, [accountId]);
+
+  useEffect(() => {
+    const nextBaseId = initialConfig.baseId ?? '';
+    const nextBaseName = initialConfig.baseName ?? initialConfig.baseId ?? '';
+    const nextTableId = initialConfig.tableId ?? '';
+    const nextTableName = initialConfig.tableName ?? initialConfig.tableId ?? '';
+
+    setSelectedBase(nextBaseId);
+    setSelectedTable(nextTableId);
+
+    if (nextBaseId) {
+      setBases((prev) =>
+        mergeUnique([
+          {
+            id: nextBaseId,
+            name: nextBaseName || nextBaseId,
+          },
+          ...prev,
+        ])
+      );
+    }
+
+    if (nextTableId) {
+      setTables((prev) =>
+        mergeUnique([
+          {
+            id: nextTableId,
+            name: nextTableName || nextTableId,
+          },
+          ...prev,
+        ])
+      );
+    }
+  }, [initialConfig.baseId, initialConfig.baseName, initialConfig.tableId, initialConfig.tableName]);
+
+  useEffect(() => {
+    if (accountId) {
+      fetchBases();
+    }
+  }, [accountId, fetchBases]);
+
+  useEffect(() => {
+    if (selectedBase) {
+      fetchTables(selectedBase);
+    } else {
+      setTables([]);
+      setSelectedTable('');
+    }
+  }, [selectedBase, fetchTables]);
+
+  const selectedTableInfo = useMemo(
+    () => tables.find((table) => table.id === selectedTable),
+    [tables, selectedTable],
+  );
+
+  useEffect(() => {
+    if (typeof onFieldsPreview !== 'function') {
+      return;
+    }
+    if (!selectedBase || !selectedTable) {
+      onFieldsPreview([]);
+      return;
+    }
+    const previewFields = selectedTableInfo?.fields ?? [];
+    onFieldsPreview(previewFields);
+  }, [onFieldsPreview, selectedBase, selectedTable, selectedTableInfo]);
+
+
+  const handleSave = useCallback(async () => {
+    if (!selectedBase || !selectedTable) {
+      toast.error('Select both a base and table');
+      return;
+    }
+    try {
+      setSaving(true);
+      const baseName = bases.find((base) => base.id === selectedBase)?.name || selectedBase;
+      const tableName = selectedTableInfo?.name || selectedTable;
+
+      const updates = [
+        ['referenceParameters.source.baseId', selectedBase],
+        ['referenceParameters.source.baseName', baseName],
+        ['referenceParameters.source.tableId', selectedTable],
+        ['referenceParameters.source.tableName', tableName],
+      ];
+
+      for (const [path, value] of updates) {
+        await primitive.setField(path, value);
+      }
+
+      if (selectedTableInfo?.fields) {
+        await primitive.setField('referenceParameters.source.tableFields', selectedTableInfo.fields);
+      }
+
+      toast.success('External source updated');
+    } catch (error) {
+      console.error(error);
+      toast.error(error.message || 'Failed to update primitive');
+    } finally {
+      setSaving(false);
+    }
+  }, [bases, primitive, selectedBase, selectedTable, selectedTableInfo]);
+
+
+  const basePlaceholder = useMemo(() => {
+    if (loadingBases) {
+      return 'Loading bases…';
+    }
+    if (!selectedBase && initialConfig.baseName) {
+      return initialConfig.baseName;
+    }
+    if (!selectedBase && initialConfig.baseId) {
+      return initialConfig.baseId;
+    }
+    return 'Select a base';
+  }, [initialConfig.baseId, initialConfig.baseName, loadingBases, selectedBase]);
+
+  const tablePlaceholder = useMemo(() => {
+    if (!selectedBase) {
+      if (!initialConfig.baseId) {
+        return 'Select a base first';
+      }
+      return `Select a table from ${initialConfig.baseName || initialConfig.baseId}`;
+    }
+    if (loadingTables) {
+      return 'Loading tables…';
+    }
+    if (!selectedTable && initialConfig.tableName) {
+      return initialConfig.tableName;
+    }
+    if (!selectedTable && initialConfig.tableId) {
+      return initialConfig.tableId;
+    }
+    return 'Select a table';
+  }, [
+    initialConfig.baseId,
+    initialConfig.baseName,
+    initialConfig.tableId,
+    initialConfig.tableName,
+    loadingTables,
+    selectedBase,
+    selectedTable,
+  ]);
+
+  if (!accountId) {
+    return (
+      <p className="mt-3 text-sm text-warning-500">
+        No integration account is linked to this primitive. Connect an account first.
+      </p>
+    );
+  }
+
+  return (
+    <div className="mt-4 space-y-4">
+      <div className="space-y-2">
+        <label className="text-sm font-medium text-default-600">Base</label>
+        <Select
+          variant="bordered"
+          selectedKeys={selectedBase ? [selectedBase] : []}
+          onChange={(event) => {
+            const value = event.target.value;
+            setSelectedBase(value);
+            setSelectedTable('');
+          }}
+          placeholder={basePlaceholder}
+          isDisabled={loadingBases}
+        >
+          {bases.map((base) => (
+            <SelectItem key={base.id} textValue={base.name ?? base.id}>
+              {base.name ?? base.id}
+            </SelectItem>
+          ))}
+        </Select>
+        {loadingBases && (
+          <div className="flex items-center gap-2 text-sm text-default-400">
+            <Spinner size="sm" />
+            <span>Loading bases…</span>
+          </div>
+        )}
+      </div>
+
+      <div className="space-y-2">
+        <label className="text-sm font-medium text-default-600">Table</label>
+        <Select
+          variant="bordered"
+          selectedKeys={selectedTable ? [selectedTable] : []}
+          onChange={(event) => setSelectedTable(event.target.value)}
+          placeholder={tablePlaceholder}
+          isDisabled={!selectedBase || loadingTables}
+        >
+          {tables.map((table) => (
+            <SelectItem key={table.id} textValue={table.name ?? table.id}>
+              {table.name ?? table.id}
+            </SelectItem>
+          ))}
+        </Select>
+        {loadingTables && (
+          <div className="flex items-center gap-2 text-sm text-default-400">
+            <Spinner size="sm" />
+            <span>Loading tables…</span>
+          </div>
+        )}
+      </div>
+
+      {selectedTableInfo?.fields?.length > 0 && (
+        <div className="space-y-2">
+          <Divider />
+          <p className="text-sm font-medium text-default-600">Fields</p>
+          <div className="flex flex-wrap gap-2 text-xs text-default-500">
+            {selectedTableInfo.fields.map((field) => (
+              <span
+                key={field.id}
+                className="rounded-full border border-default-200 px-2 py-1"
+              >
+                {field.name} · {field.type}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <div className="flex justify-end gap-2">
+        <Button
+          color="primary"
+          onPress={handleSave}
+          isDisabled={!selectedBase || !selectedTable || saving}
+          isLoading={saving}
+        >
+          Save Configuration
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/integrations/ExternalPrimitiveConfigurator.jsx
+++ b/ui/src/integrations/ExternalPrimitiveConfigurator.jsx
@@ -1,0 +1,130 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import AirtablePrimitiveConfigurator from './AirtablePrimitiveConfigurator.jsx';
+import ExternalPrimitiveMappingsEditor from './ExternalPrimitiveMappingsEditor.jsx';
+
+export default function ExternalPrimitiveConfigurator({ primitive, provider, loadingProviders }) {
+  const providerName = primitive?.referenceParameters?.provider;
+  const accountId = primitive?.referenceParameters?.integrationAccountId
+    ?? primitive?.resources?.integration?.accountId
+    ?? primitive?.referenceParameters?.accountId;
+
+  const primitiveFields = provider?.configuration?.primitive ?? [];
+
+  const providerSupportsPrimitiveConfig = primitiveFields.length > 0;
+  const providerLoading = loadingProviders || (providerName && provider === undefined);
+
+  const deriveAvailableFields = useCallback((targetPrimitive) => {
+    const source = targetPrimitive?.referenceParameters?.source ?? {};
+    if (Array.isArray(source.tableFields) && source.tableFields.length > 0) {
+      return source.tableFields;
+    }
+    if (source.fields && typeof source.fields === 'object') {
+      return Object.entries(source.fields).map(([name, details]) => ({
+        id: name,
+        name: details?.name ?? name,
+        type: details?.type,
+      }));
+    }
+    const sample = targetPrimitive?.referenceParameters?.sampleRecord?.fields;
+    if (sample && typeof sample === 'object') {
+      return Object.keys(sample).map((name) => ({ id: name, name }));
+    }
+    return [];
+  }, []);
+
+  const [availableFields, setAvailableFields] = useState(() => deriveAvailableFields(primitive));
+
+  useEffect(() => {
+    setAvailableFields(deriveAvailableFields(primitive));
+  }, [deriveAvailableFields, primitive?.referenceParameters]);
+
+  const handleFieldsPreview = useCallback((fields) => {
+    setAvailableFields(Array.isArray(fields) ? fields : []);
+  }, []);
+
+  const configurator = useMemo(() => {
+    if (!providerName || !providerSupportsPrimitiveConfig) {
+      return null;
+    }
+
+    switch (providerName) {
+      case 'airtable':
+        return (
+          <AirtablePrimitiveConfigurator
+            primitive={primitive}
+            accountId={accountId}
+            onFieldsPreview={handleFieldsPreview}
+          />
+        );
+      default:
+        return null;
+    }
+  }, [accountId, handleFieldsPreview, primitive, providerName, providerSupportsPrimitiveConfig]);
+
+  const providerSection = useMemo(() => {
+    if (providerLoading && !provider) {
+      return (
+        <p className="mt-3 text-sm text-default-500">Loading provider details…</p>
+      );
+    }
+
+    if (!providerName) {
+      return (
+        <p className="mt-3 text-sm text-default-500">
+          Set a provider for this external primitive to configure it.
+        </p>
+      );
+    }
+
+    if (!provider) {
+      return (
+        <p className="mt-3 text-sm text-danger-500">
+          Provider "{providerName}" is not registered. Please reconnect the integration.
+        </p>
+      );
+    }
+
+    if (!providerSupportsPrimitiveConfig) {
+      return (
+        <p className="mt-3 text-sm text-default-500">
+          {provider.title || provider.name} does not require additional configuration for each primitive.
+        </p>
+      );
+    }
+
+    if (!accountId) {
+      return (
+        <p className="mt-3 text-sm text-warning-500">
+          Connect this primitive to an integration account before configuring it.
+        </p>
+      );
+    }
+
+    if (!configurator) {
+      return (
+        <p className="mt-3 text-sm text-default-500">
+          Configuration UI for {provider.title || provider.name} is not yet available.
+        </p>
+      );
+    }
+
+    return configurator;
+  }, [
+    accountId,
+    configurator,
+    providerLoading,
+    provider,
+    providerName,
+    providerSupportsPrimitiveConfig,
+  ]);
+
+  return (
+    <div className="space-y-6">
+      {providerSection}
+      <ExternalPrimitiveMappingsEditor
+        primitive={primitive}
+        availableFields={availableFields}
+      />
+    </div>
+  );
+}

--- a/ui/src/integrations/ExternalPrimitiveMappingsEditor.jsx
+++ b/ui/src/integrations/ExternalPrimitiveMappingsEditor.jsx
@@ -1,0 +1,702 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  Button,
+  Card,
+  CardBody,
+  CardHeader,
+  Divider,
+  Input,
+  Select,
+  SelectItem,
+  Table,
+  TableHeader,
+  TableColumn,
+  TableBody,
+  TableRow,
+  TableCell,
+} from '@heroui/react';
+import toast from 'react-hot-toast';
+import CategoryIdSelector from '../@components/CategoryIdSelector.jsx';
+import MainStore from '../MainStore';
+
+const mainstore = MainStore();
+
+const TARGET_PREFIX = 'referenceParameters.';
+
+const compactInputClassNames = {
+  label: 'text-xs font-medium text-default-500',
+  inputWrapper: 'h-8 min-h-8 px-2.5 py-1 rounded-medium',
+  innerWrapper: 'h-full',
+  input: 'text-small',
+};
+
+const compactSelectClassNames = {
+  label: 'text-xs font-medium text-default-500',
+  trigger: 'h-8 min-h-8 px-2.5 py-1 rounded-medium',
+  value: 'text-small',
+};
+
+const compactTableClassNames = {
+  wrapper: 'p-0',
+  table: 'text-small',
+  thead: 'bg-default-100 text-default-500',
+  th: 'py-1.5 px-2 text-xs font-medium uppercase tracking-wide',
+  td: 'py-1.5 px-2 align-middle',
+  tr: 'border-b border-default-200 last:border-b-0',
+};
+
+const getTypeForCategory = (categoryId) => {
+  if (categoryId === undefined || categoryId === null || categoryId === '') {
+    return undefined;
+  }
+  const category = mainstore.category(categoryId);
+  return category?.primitiveType || category?.type || undefined;
+};
+
+const getParameterKeyFromTarget = (target) => {
+  if (typeof target !== 'string' || target.length === 0) {
+    return null;
+  }
+  if (target.startsWith(TARGET_PREFIX)) {
+    const remainder = target.slice(TARGET_PREFIX.length);
+    const [firstSegment] = remainder.split('.');
+    return firstSegment || null;
+  }
+  return null;
+};
+
+const buildCategoryFieldOptions = (category) => {
+  const options = [
+    {
+      key: 'title',
+      label: 'Title',
+      description: 'Sets the child primitive title',
+    },
+  ];
+
+  if (!category || typeof category !== 'object') {
+    return options;
+  }
+  const parameters = category.parameters;
+  if (!parameters || typeof parameters !== 'object') {
+    return options;
+  }
+  Object.entries(parameters).forEach(([key, parameter]) => {
+    const label = parameter?.title || parameter?.label || key;
+    const optionKey = `${TARGET_PREFIX}${key}`;
+    options.push({
+      key: optionKey,
+      label,
+      description: parameter?.description,
+    });
+  });
+  return options;
+};
+
+function createId(prefix = 'id') {
+  return `${prefix}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function normalizeMappings(raw) {
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+  return raw.map((mapping, index) => {
+    const fieldMap = mapping.fieldMap && typeof mapping.fieldMap === 'object'
+      ? Object.entries(mapping.fieldMap).map(([target, source], idx) => ({
+          id: createId(`field-${index}-${idx}`),
+          target,
+          source: typeof source === 'string' ? source : JSON.stringify(source),
+        }))
+      : [];
+    const staticFields = mapping.staticFields && typeof mapping.staticFields === 'object'
+      ? Object.entries(mapping.staticFields).map(([target, value], idx) => ({
+          id: createId(`static-${index}-${idx}`),
+          target,
+          value: typeof value === 'string' ? value : JSON.stringify(value),
+        }))
+      : [];
+
+    const referenceId = mapping.referenceId ?? null;
+
+    return {
+      id: createId(`mapping-${index}`),
+      key: mapping.key ?? '',
+      referenceId,
+      titleField: mapping.titleField ?? '',
+      fieldMap,
+      staticFields,
+      computedType: getTypeForCategory(referenceId),
+    };
+  });
+}
+
+function serializeMappings(list) {
+  return list.map((mapping) => {
+    const result = {};
+
+    if (mapping.key) {
+      result.key = mapping.key;
+    }
+
+    if (mapping.referenceId !== undefined && mapping.referenceId !== null && mapping.referenceId !== '') {
+      const referenceId = Number(mapping.referenceId);
+      result.referenceId = Number.isNaN(referenceId) ? mapping.referenceId : referenceId;
+    }
+
+    if (mapping.titleField) {
+      result.titleField = mapping.titleField;
+    }
+
+    const fieldMap = (mapping.fieldMap ?? []).reduce((acc, row) => {
+      const target = String(row.target || '').trim();
+      const source = row.source !== undefined && row.source !== null ? String(row.source).trim() : '';
+      if (target && source) {
+        acc[target] = source;
+      }
+      return acc;
+    }, {});
+    if (Object.keys(fieldMap).length > 0) {
+      result.fieldMap = fieldMap;
+    }
+
+    const staticFields = (mapping.staticFields ?? []).reduce((acc, row) => {
+      const target = String(row.target || '').trim();
+      if (!target) {
+        return acc;
+      }
+      const value = row.value ?? '';
+      acc[target] = value;
+      return acc;
+    }, {});
+    if (Object.keys(staticFields).length > 0) {
+      result.staticFields = staticFields;
+    }
+
+    return result;
+  });
+}
+
+export default function ExternalPrimitiveMappingsEditor({ primitive, availableFields = [] }) {
+  const [mappings, setMappings] = useState(() => normalizeMappings(primitive?.referenceParameters?.mappings));
+  const [dirty, setDirty] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    setMappings(normalizeMappings(primitive?.referenceParameters?.mappings));
+    setDirty(false);
+  }, [primitive?.id, primitive?.referenceParameters?.mappings]);
+
+  const fieldOptions = useMemo(() => {
+    const list = (availableFields ?? [])
+      .map((field) => {
+        if (!field) return null;
+        if (typeof field === 'string') {
+          return { key: field, label: field };
+        }
+        const name = field.name ?? field.id;
+        if (!name) return null;
+        return { key: name, label: name, type: field.type };
+      })
+      .filter(Boolean);
+
+    const seen = new Map();
+    list.forEach((option) => {
+      const key = String(option.key);
+      const lowerKey = key.toLowerCase();
+      if (!seen.has(lowerKey)) {
+        seen.set(lowerKey, { ...option, lowerKey });
+      }
+    });
+
+    return Array.from(seen.values());
+  }, [availableFields]);
+
+  const fieldOptionLookup = useMemo(() => {
+    const map = new Map();
+    fieldOptions.forEach((option) => {
+      const key = String(option.key).toLowerCase();
+      map.set(key, option);
+    });
+    return map;
+  }, [fieldOptions]);
+
+  const categoryFieldOptionsById = useMemo(() => {
+    const map = new Map();
+    mappings.forEach((mapping) => {
+      const refId = mapping.referenceId;
+      if (!refId || map.has(refId)) {
+        return;
+      }
+      const category = mainstore.category(refId);
+      const options = buildCategoryFieldOptions(category);
+      if (options.length > 1) {
+        options.sort((a, b) => a.label.localeCompare(b.label, undefined, { sensitivity: 'base' }));
+      }
+      map.set(refId, options);
+    });
+    return map;
+  }, [mappings]);
+
+  const updateMapping = (index, updater) => {
+    setMappings((current) =>
+      current.map((mapping, idx) => {
+        if (idx !== index) {
+          return mapping;
+        }
+        let updates = typeof updater === 'function' ? updater(mapping) : updater;
+        if (Object.prototype.hasOwnProperty.call(updates ?? {}, 'referenceId')) {
+          updates = {
+            ...updates,
+            computedType: getTypeForCategory(updates.referenceId),
+          };
+        }
+        return { ...mapping, ...updates };
+      }),
+    );
+    setDirty(true);
+  };
+
+  const updateFieldMapRow = (mappingIndex, rowId, updates) => {
+    setMappings((current) =>
+      current.map((mapping, idx) => {
+        if (idx !== mappingIndex) {
+          return mapping;
+        }
+        const nextFieldMap = (mapping.fieldMap ?? []).map((row) =>
+          row.id === rowId ? { ...row, ...updates } : row,
+        );
+        return { ...mapping, fieldMap: nextFieldMap };
+      }),
+    );
+    setDirty(true);
+  };
+
+  const updateStaticFieldRow = (mappingIndex, rowId, updates) => {
+    setMappings((current) =>
+      current.map((mapping, idx) => {
+        if (idx !== mappingIndex) {
+          return mapping;
+        }
+        const nextStaticFields = (mapping.staticFields ?? []).map((row) =>
+          row.id === rowId ? { ...row, ...updates } : row,
+        );
+        return { ...mapping, staticFields: nextStaticFields };
+      }),
+    );
+    setDirty(true);
+  };
+
+  const addMapping = () => {
+    setMappings((current) => [
+      ...current,
+      {
+        id: createId('mapping-new'),
+        key: '',
+        referenceId: null,
+        titleField: '',
+        fieldMap: [],
+        staticFields: [],
+        computedType: undefined,
+      },
+    ]);
+    setDirty(true);
+  };
+
+  const removeMapping = (mappingId) => {
+    setMappings((current) => current.filter((mapping) => mapping.id !== mappingId));
+    setDirty(true);
+  };
+
+  const addFieldMapRow = (mappingIndex) => {
+    setMappings((current) =>
+      current.map((mapping, idx) => {
+        if (idx !== mappingIndex) {
+          return mapping;
+        }
+        const next = [...(mapping.fieldMap ?? []), { id: createId('field'), target: '', source: '' }];
+        return { ...mapping, fieldMap: next };
+      }),
+    );
+    setDirty(true);
+  };
+
+  const addStaticFieldRow = (mappingIndex) => {
+    setMappings((current) =>
+      current.map((mapping, idx) => {
+        if (idx !== mappingIndex) {
+          return mapping;
+        }
+        const next = [...(mapping.staticFields ?? []), { id: createId('static'), target: '', value: '' }];
+        return { ...mapping, staticFields: next };
+      }),
+    );
+    setDirty(true);
+  };
+
+  const removeFieldMapRow = (mappingIndex, rowId) => {
+    setMappings((current) =>
+      current.map((mapping, idx) => {
+        if (idx !== mappingIndex) {
+          return mapping;
+        }
+        const next = (mapping.fieldMap ?? []).filter((row) => row.id !== rowId);
+        return { ...mapping, fieldMap: next };
+      }),
+    );
+    setDirty(true);
+  };
+
+  const removeStaticFieldRow = (mappingIndex, rowId) => {
+    setMappings((current) =>
+      current.map((mapping, idx) => {
+        if (idx !== mappingIndex) {
+          return mapping;
+        }
+        const next = (mapping.staticFields ?? []).filter((row) => row.id !== rowId);
+        return { ...mapping, staticFields: next };
+      }),
+    );
+    setDirty(true);
+  };
+
+  const resetChanges = () => {
+    setMappings(normalizeMappings(primitive?.referenceParameters?.mappings));
+    setDirty(false);
+  };
+
+  const handleSave = async () => {
+    if (!primitive) {
+      return;
+    }
+
+    const serialized = serializeMappings(mappings);
+
+    const prepared = serialized.map((mapping) => {
+      const { computedType, ...rest } = mapping;
+      const category = mapping.referenceId ? mainstore.category(mapping.referenceId) : undefined;
+      const type = category?.primitiveType || category?.type || 'result';
+      return {
+        ...rest,
+        type,
+      };
+    });
+
+    const invalid = prepared.filter((mapping) => !mapping.referenceId || !mapping.type);
+    if (invalid.length > 0) {
+      toast.error('Each mapping needs a category that defines a primitive type.');
+      return;
+    }
+
+    try {
+      setSaving(true);
+      const cleaned = prepared.filter((mapping) => mapping.referenceId);
+      await primitive.setField('referenceParameters.mappings', cleaned);
+      toast.success('Mappings saved');
+      setDirty(false);
+    } catch (error) {
+      console.error(error);
+      toast.error(error.message || 'Unable to save mappings');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-col gap-1">
+        <div className="flex items-center justify-between gap-2">
+          <div>
+            <h4 className="text-base font-semibold text-foreground">Record mappings</h4>
+            <p className="text-sm text-default-500">
+              Create child primitives for each incoming record. You can add multiple mappings and reuse record fields across them.
+            </p>
+          </div>
+          <Button size="sm" variant="bordered" onPress={addMapping}>
+            Add mapping
+          </Button>
+        </div>
+      </div>
+
+      {mappings.length === 0 ? (
+        <div className="rounded-large border border-dashed border-default-300 bg-default-100/60 p-6 text-sm text-default-500">
+          No mappings defined yet.
+        </div>
+      ) : (
+        mappings.map((mapping, index) => (
+          <Card key={mapping.id} shadow="sm" className="border border-default-200">
+            <CardHeader className="flex flex-wrap items-start justify-between gap-2 px-3 py-2.5">
+              <div>
+                <Input
+                  label="Mapping key"
+                  labelPlacement="outside-left"
+                  variant="bordered"
+                  value={mapping.key}
+                  onChange={(event) => updateMapping(index, { key: event.target.value })}
+                  size="sm"
+                  classNames={compactInputClassNames}
+                />
+              </div>
+              <Button
+                size="sm"
+                color="danger"
+                variant="light"
+                onPress={() => removeMapping(mapping.id)}
+              >
+                Remove
+              </Button>
+            </CardHeader>
+            <Divider />
+            <CardBody className="space-y-3 px-3 py-3">
+              <div className="space-y-2">
+                <p className="text-sm font-medium text-default-600">Category</p>
+                <CategoryIdSelector
+                  allowNone
+                  selectionMode="single"
+                  showCount={false}
+                  className="max-w-full"
+                  selectedValues={mapping.referenceId ? [String(mapping.referenceId)] : []}
+                  onSelectionChange={(selections) => {
+                    const selection = selections?.[0];
+                    if (!selection || selection.categoryId === undefined || selection.categoryId === null) {
+                      updateMapping(index, { referenceId: null });
+                    } else {
+                      updateMapping(index, { referenceId: selection.categoryId });
+                    }
+                  }}
+                />
+              </div>
+
+              <div className="space-y-1.5">
+                <div className="flex items-center justify-between gap-2">
+                  <p className="text-sm font-medium text-default-600">Field mappings</p>
+                  <Button size="sm" variant="bordered" onPress={() => addFieldMapRow(index)}>
+                    Add field mapping
+                  </Button>
+                </div>
+                {(mapping.fieldMap ?? []).length === 0 ? (
+                  <p className="text-xs text-default-500">Map record fields to primitive fields.</p>
+                ) : (
+                  <Table
+                    aria-label="Field mappings"
+                  shadow="none"
+                  className="border border-default-200"
+                  removeWrapper
+                  classNames={compactTableClassNames}
+                  >
+                    <TableHeader>
+                      <TableColumn>Primitive field</TableColumn>
+                      <TableColumn>Record field</TableColumn>
+                      <TableColumn align="end">Actions</TableColumn>
+                    </TableHeader>
+                    <TableBody emptyContent="No field mappings">
+                      {mapping.fieldMap.map((row) => {
+                        const categoryOptions = categoryFieldOptionsById.get(mapping.referenceId) ?? [];
+                        const parameterKey = getParameterKeyFromTarget(row.target);
+                        const normalizedKey = parameterKey ? `${TARGET_PREFIX}${parameterKey}` : row.target;
+                        const hasMatchingOption = Boolean(normalizedKey) && categoryOptions.some((option) => option.key === normalizedKey);
+                        const disableSelect = !mapping.referenceId || categoryOptions.length === 0;
+                        // Include the previously saved path when it no longer matches a known parameter.
+                        const optionsToRender = disableSelect
+                          ? categoryOptions
+                          : hasMatchingOption || !row.target
+                          ? categoryOptions
+                          : [
+                              ...categoryOptions,
+                              {
+                                key: row.target,
+                                label: row.target,
+                                description: 'Custom path',
+                              },
+                            ];
+                        const selectedKey = hasMatchingOption ? normalizedKey : row.target;
+                        const selectPlaceholder = !mapping.referenceId
+                          ? 'Select a category to choose fields'
+                          : categoryOptions.length === 0
+                          ? 'No fields available'
+                          : 'Select a primitive field';
+
+                        const rawSource = row.source ?? '';
+                        const matchedFieldOption = rawSource
+                          ? fieldOptionLookup.get(String(rawSource).toLowerCase())
+                          : undefined;
+                        const recordHasMatchingOption = Boolean(matchedFieldOption);
+                        const recordSelectedKey = recordHasMatchingOption ? matchedFieldOption.key : rawSource;
+                        const recordOptionsToRender = recordHasMatchingOption || !rawSource
+                          ? fieldOptions
+                          : [
+                              ...fieldOptions,
+                              {
+                                key: rawSource,
+                                label: rawSource,
+                                description: 'Custom field',
+                              },
+                            ];
+                        const recordSelectPlaceholder = recordOptionsToRender.length === 0
+                          ? 'No fields available'
+                          : 'Select a record field';
+
+                        return (
+                          <TableRow key={row.id}>
+                            <TableCell>
+                              {disableSelect ? (
+                                <Input
+                                  variant="bordered"
+                                  value={row.target}
+                                  onChange={(event) => updateFieldMapRow(index, row.id, { target: event.target.value })}
+                                  placeholder={mapping.referenceId ? 'Enter primitive field path' : 'Select a category to enable'}
+                                  size="sm"
+                                  classNames={compactInputClassNames}
+                                />
+                              ) : (
+                                <Select
+                                  aria-label="Primitive field"
+                                  variant="bordered"
+                                  selectedKeys={selectedKey ? [selectedKey] : []}
+                                  onChange={(event) => updateFieldMapRow(index, row.id, { target: event.target.value })}
+                                  placeholder={selectPlaceholder}
+                                  size="sm"
+                                  classNames={compactSelectClassNames}
+                                  menuTrigger="focus"
+                                  popoverProps={{
+                                    classNames: {
+                                      base: 'min-w-[16rem]',
+                                    },
+                                  }}
+                                >
+                                  {optionsToRender.map((option) => (
+                                    <SelectItem
+                                      key={option.key}
+                                      description={
+                                        option.description
+                                          ? option.description
+                                          : typeof option.key === 'string' && option.key.startsWith(TARGET_PREFIX)
+                                          ? option.key.slice(TARGET_PREFIX.length)
+                                          : undefined
+                                      }
+                                    >
+                                      {option.label}
+                                    </SelectItem>
+                                  ))}
+                                </Select>
+                              )}
+                            </TableCell>
+                            <TableCell>
+                              <Select
+                                variant="bordered"
+                                selectedKeys={recordSelectedKey ? [recordSelectedKey] : []}
+                                onChange={(event) => updateFieldMapRow(index, row.id, { source: event.target.value })}
+                                placeholder={recordSelectPlaceholder}
+                                size="sm"
+                                isDisabled={recordOptionsToRender.length === 0}
+                                classNames={compactSelectClassNames}
+                                menuTrigger="focus"
+                                popoverProps={{
+                                  classNames: {
+                                    base: 'min-w-[16rem]',
+                                  },
+                                }}
+                              >
+                                {recordOptionsToRender.map((option) => (
+                                  <SelectItem
+                                    key={option.key}
+                                    description={option.description}
+                                  >
+                                    {option.label}
+                                  </SelectItem>
+                                ))}
+                              </Select>
+                            </TableCell>
+                            <TableCell>
+                              <div className="flex justify-end">
+                                <Button
+                                  size="sm"
+                                  variant="light"
+                                  color="danger"
+                                  onPress={() => removeFieldMapRow(index, row.id)}
+                                >
+                                  Remove
+                                </Button>
+                              </div>
+                            </TableCell>
+                          </TableRow>
+                        )
+                      })}
+                    </TableBody>
+                  </Table>
+                )}
+              </div>
+
+              <Divider />
+
+              <div className="space-y-2">
+                <div className="flex items-center justify-between gap-2">
+                  <p className="text-sm font-medium text-default-600">Static fields</p>
+                  <Button size="sm" variant="bordered" onPress={() => addStaticFieldRow(index)}>
+                    Add static field
+                  </Button>
+                </div>
+                {(mapping.staticFields ?? []).length === 0 ? (
+                  <p className="text-xs text-default-500">Add constant values to the child primitive.</p>
+                ) : (
+                  <div className="space-y-2">
+                    {mapping.staticFields.map((row) => (
+                      <div key={row.id} className="space-y-2 rounded-large border border-default-200 bg-default-100/60 p-2.5">
+                        <Input
+                          label="Target path"
+                          variant="bordered"
+                          value={row.target}
+                          onChange={(event) => updateStaticFieldRow(index, row.id, { target: event.target.value })}
+                          placeholder="e.g. referenceParameters.source"
+                          size="sm"
+                          classNames={compactInputClassNames}
+                        />
+                        <Input
+                          label="Value"
+                          variant="bordered"
+                          value={row.value}
+                          onChange={(event) => updateStaticFieldRow(index, row.id, { value: event.target.value })}
+                          placeholder="Literal value"
+                          size="sm"
+                          classNames={compactInputClassNames}
+                        />
+                        <div className="flex justify-end">
+                          <Button
+                            size="sm"
+                            variant="light"
+                            color="danger"
+                            onPress={() => removeStaticFieldRow(index, row.id)}
+                          >
+                            Remove
+                          </Button>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </CardBody>
+          </Card>
+        ))
+      )}
+
+      <div className="flex items-center justify-end gap-2">
+        <Button
+          variant="flat"
+          onPress={resetChanges}
+          isDisabled={!dirty || saving}
+        >
+          Reset
+        </Button>
+        <Button
+          color="primary"
+          onPress={handleSave}
+          isDisabled={!dirty || saving}
+          isLoading={saving}
+        >
+          Save mappings
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/integrations/IntegrationConfigModal.jsx
+++ b/ui/src/integrations/IntegrationConfigModal.jsx
@@ -1,0 +1,107 @@
+import React, { useMemo, useState } from 'react';
+import { Modal, ModalBody, ModalContent, ModalHeader } from '@heroui/react';
+import toast from 'react-hot-toast';
+import AirtableConfigurator from './AirtableConfigurator.jsx';
+
+export default function IntegrationConfigModal({
+  isOpen,
+  onClose,
+  provider,
+  account,
+  onAccountUpdated,
+}) {
+  const [saving, setSaving] = useState(false);
+
+  const providerName = provider?.name ?? account?.provider;
+
+  const handleClose = () => {
+    if (saving) {
+      return;
+    }
+    setSaving(false);
+    onClose?.();
+  };
+
+  const handleSave = async (payload) => {
+    if (!account?.id) {
+      return;
+    }
+    try {
+      setSaving(true);
+      const response = await fetch(`/api/integrations/accounts/${account.id}`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          metadata: {
+            ...(account.metadata ?? {}),
+            [providerName]: payload,
+          },
+        }),
+      });
+      if (!response.ok) {
+        const body = await response.json().catch(() => ({}));
+        throw new Error(body?.error || `Failed to save configuration (${response.status})`);
+      }
+      const body = await response.json();
+      const updatedAccount = body?.account;
+      if (updatedAccount) {
+        onAccountUpdated?.(updatedAccount);
+      }
+      toast.success('Configuration saved');
+      setSaving(false);
+      onClose?.();
+    } catch (error) {
+      console.error(error);
+      toast.error(error.message || 'Unable to save configuration');
+      setSaving(false);
+    }
+  };
+
+  const content = useMemo(() => {
+    if (!providerName || !account) {
+      return null;
+    }
+    switch (providerName) {
+      case 'airtable':
+        return (
+          <AirtableConfigurator
+            account={account}
+            saving={saving}
+            onSubmit={handleSave}
+            onCancel={handleClose}
+          />
+        );
+      default:
+        return (
+          <div className="space-y-3">
+            <p className="text-sm text-default-500">
+              Configuration for this integration is not yet supported.
+            </p>
+          </div>
+        );
+    }
+  }, [account, handleClose, handleSave, providerName, saving]);
+
+  const modalTitle = provider?.title || provider?.name || account?.provider || 'Integration';
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={handleClose}
+      isDismissable={!saving}
+      size="lg"
+      scrollBehavior="inside"
+    >
+      <ModalContent>
+        <ModalHeader className="flex flex-col gap-1 text-lg font-semibold">
+          Configure {modalTitle}
+        </ModalHeader>
+        <ModalBody>
+          {content}
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/ui/src/setupProxy.js
+++ b/ui/src/setupProxy.js
@@ -2,7 +2,7 @@ const { createProxyMiddleware } = require('http-proxy-middleware');
 
 module.exports = function(app) {
   app.use(
-    ['/google', '/logout', '/auth/', '/stripe', '/api/*', '/images/*', '/socket.io/*','/published/*'],
+    ['/google', '/logout', '/auth/', '/stripe', '/api/*', '/images/*', '/socket.io/*','/published/*', 'integrations'],
     createProxyMiddleware({
       target:  process.env.PROXY,
       //target:  'http://localhost:3001',


### PR DESCRIPTION
## Summary
- add an integrations screen that lists providers, existing accounts, and launches OAuth authorization
- expose the new screen in the app shell via the sidebar navigation and route table so users can reach it easily

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68df5c6364c08330a3246cc04371ee66