### PR TITLE
Stop caching integration records in primitive resources

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -7,6 +7,7 @@ import indexRouter from './routes/index';
 import apiRouter from './routes/api';
 import publishedRouter from './routes/published';
 import authRouter from './routes/auth';
+import integrationsRouter from './routes/integrations';
 import passport from 'passport';
 import cookieSession from 'cookie-session';
 import bodyParser from 'body-parser'
@@ -388,6 +389,7 @@ app.use(
     })
   );
 
+app.use('/api/integrations', integrationsRouter);
 app.use('/api', apiRouter);
 
 app.get("/google/failed", (req, res) => {

--- a/server/integration_queue.js
+++ b/server/integration_queue.js
@@ -1,0 +1,85 @@
+import BaseQueue from './base_queue';
+import { getLogger } from './logger.js';
+import { fetchPrimitive, dispatchControlUpdate } from './SharedFunctions.js';
+import { syncExternalPrimitive } from './integrations/index.js';
+
+const logger = getLogger('integration_queue', 'debug');
+
+let instance;
+
+export async function processQueue(job, cancelCheck) {
+  return IntegrationQueue().process(job, cancelCheck);
+}
+
+class IntegrationQueueClass extends BaseQueue {
+  constructor() {
+    super('integration', undefined, 2);
+  }
+
+  async enqueueSync(primitive, options = {}) {
+    const field = options.field ?? 'processing.integration.sync';
+    if (primitive.processing?.integration?.sync?.status === 'pending') {
+      logger.info(`Sync already pending for external primitive ${primitive.id}`);
+      return false;
+    }
+    const data = {
+      id: primitive.id ?? primitive._id?.toString?.(),
+      mode: 'sync',
+      field,
+      options: {
+        provider: options.provider,
+        accountId: options.accountId,
+        since: options.since,
+      },
+    };
+    await this.addJob(primitive.workspaceId, data, options.jobOptions);
+    return true;
+  }
+
+  async process(job, cancelCheck) {
+    if (job.data.mode !== 'sync') {
+      throw new Error(`Unknown integration queue mode: ${job.data.mode}`);
+    }
+    const primitiveId = job.data.id;
+    const primitive = await fetchPrimitive(primitiveId);
+    if (!primitive) {
+      throw new Error(`Primitive ${primitiveId} not found`);
+    }
+    const field = job.data.field ?? 'processing.integration.sync';
+
+    dispatchControlUpdate(primitive.id, field, {
+      status: 'running',
+      started: new Date().toISOString(),
+      track: primitive.id,
+    });
+
+    try {
+      const result = await syncExternalPrimitive(primitive, job.data.options ?? {});
+      dispatchControlUpdate(primitive.id, field, {
+        status: 'complete',
+        completed: new Date().toISOString(),
+        track: primitive.id,
+        summary: result,
+      });
+      logger.info(`External sync complete for ${primitive.id}`, result);
+      return result;
+    } catch (error) {
+      logger.error(`External sync failed for ${primitive.id}`, error);
+      dispatchControlUpdate(primitive.id, field, {
+        status: 'error',
+        error: error.message,
+        completed: new Date().toISOString(),
+        track: primitive.id,
+      });
+      throw error;
+    }
+  }
+}
+
+export default function IntegrationQueue() {
+  if (!instance) {
+    instance = new IntegrationQueueClass();
+    instance.myInit();
+  }
+  return instance;
+}

--- a/server/integrations/providers/airtable.js
+++ b/server/integrations/providers/airtable.js
@@ -1,0 +1,272 @@
+import { URL, URLSearchParams } from 'node:url';
+import { Buffer } from 'node:buffer';
+import { getLogger } from '../../logger.js';
+import { IntegrationProvider, registerIntegration } from '../index.js';
+
+const logger = getLogger('integration-airtable', 'debug');
+
+const AUTH_BASE = 'https://airtable.com/oauth2/v1';
+const API_BASE = 'https://api.airtable.com/v0';
+
+function getEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing environment variable ${name} for Airtable integration`);
+  }
+  return value;
+}
+
+function toIso(input) {
+  if (!input) return undefined;
+  const date = input instanceof Date ? input : new Date(input);
+  if (Number.isNaN(date.getTime())) {
+    return undefined;
+  }
+  return date.toISOString();
+}
+
+function escapeFormulaLiteral(value) {
+  if (value === undefined || value === null) {
+    return '';
+  }
+  return `'${String(value).replace(/'/g, "\\'")}'`;
+}
+
+function buildFilterFormula(config, since, filters = {}) {
+  const clauses = [];
+  const timestampField = config.timestampField || config.lastModifiedField;
+  const sinceIso = toIso(since);
+  if (timestampField && sinceIso) {
+    clauses.push(`IS_AFTER({${timestampField}}, ${escapeFormulaLiteral(sinceIso)})`);
+  }
+  const range = filters.dateRange ?? {};
+  if (timestampField && range.from) {
+    clauses.push(`IS_AFTER({${timestampField}}, ${escapeFormulaLiteral(toIso(range.from))})`);
+  }
+  if (timestampField && range.to) {
+    clauses.push(`IS_BEFORE({${timestampField}}, ${escapeFormulaLiteral(toIso(range.to))})`);
+  }
+  if (filters.formula) {
+    clauses.push(`(${filters.formula})`);
+  }
+  if (clauses.length === 0) {
+    return undefined;
+  }
+  if (clauses.length === 1) {
+    return clauses[0];
+  }
+  return `AND(${clauses.join(',')})`;
+}
+
+function normalizeRecord(record, config) {
+  const primaryField = config.primaryKeyField || config.primaryField;
+  const timestampField = config.timestampField || config.lastModifiedField;
+  const uniqueValue = primaryField ? record.fields?.[primaryField] : undefined;
+  const updatedRaw = timestampField ? record.fields?.[timestampField] : undefined;
+  const updatedAt = updatedRaw ? new Date(updatedRaw) : new Date(record.createdTime);
+  const createdAt = record.createdTime ? new Date(record.createdTime) : updatedAt;
+  const titleField = config.titleField || primaryField;
+  const title = titleField ? record.fields?.[titleField] : undefined;
+
+  return {
+    recordId: record.id,
+    externalId: uniqueValue ?? record.id,
+    uniqueValue: uniqueValue ?? record.id,
+    createdAt,
+    updatedAt,
+    title: typeof title === 'string' ? title : undefined,
+    fields: record.fields ?? {},
+    raw: record,
+  };
+}
+
+class AirtableIntegration extends IntegrationProvider {
+  constructor() {
+    super({
+      name: 'airtable',
+      title: 'Airtable',
+      scopes: ['data.records:read'],
+      description: 'Sync records from Airtable bases and tables.',
+    });
+  }
+
+  get clientId() {
+    return getEnv('AIRTABLE_CLIENT_ID');
+  }
+
+  get clientSecret() {
+    return getEnv('AIRTABLE_CLIENT_SECRET');
+  }
+
+  get defaultRedirectUri() {
+    return getEnv('AIRTABLE_OAUTH_REDIRECT');
+  }
+
+  getAuthorizationUrl({ state, redirectUri, scopes } = {}) {
+    const url = new URL(`${AUTH_BASE}/authorize`);
+    const params = new URLSearchParams({
+      client_id: this.clientId,
+      response_type: 'code',
+      redirect_uri: redirectUri || this.defaultRedirectUri,
+      scope: (scopes && scopes.length > 0 ? scopes : this.scopes).join(' '),
+      state,
+    });
+    url.search = params.toString();
+    return url.toString();
+  }
+
+  async exchangeCodeForToken({ code, redirectUri }) {
+    const params = new URLSearchParams({
+      grant_type: 'authorization_code',
+      code,
+      redirect_uri: redirectUri || this.defaultRedirectUri,
+    });
+    return this.requestToken(params);
+  }
+
+  async refreshToken(refreshToken) {
+    const params = new URLSearchParams({
+      grant_type: 'refresh_token',
+      refresh_token: refreshToken,
+    });
+    return this.requestToken(params);
+  }
+
+  async requestToken(params) {
+    const response = await fetch(`${AUTH_BASE}/token`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Basic ${Buffer.from(`${this.clientId}:${this.clientSecret}`).toString('base64')}`,
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: params,
+    });
+    if (!response.ok) {
+      const errorBody = await response.text();
+      throw new Error(`Airtable token exchange failed (${response.status}): ${errorBody}`);
+    }
+    const body = await response.json();
+    const expiresIn = body.expires_in ? Number(body.expires_in) : undefined;
+    const expiresAt = expiresIn ? new Date(Date.now() + expiresIn * 1000) : undefined;
+    return {
+      accessToken: body.access_token,
+      refreshToken: body.refresh_token,
+      expiresIn,
+      expiresAt,
+      scope: body.scope ? String(body.scope).split(' ') : undefined,
+      metadata: {
+        tokenType: body.token_type,
+      },
+    };
+  }
+
+  async fetchRecords(account, config, options = {}) {
+    if (!config?.baseId || !config?.tableId) {
+      throw new Error('Airtable configuration requires baseId and tableId');
+    }
+
+    await this.ensureAccessToken(account);
+
+    logger.debug('Fetching Airtable records', {
+      baseId: config.baseId,
+      tableId: config.tableId,
+      since: options.since,
+    });
+
+    const items = [];
+    let offset;
+    let accessToken = account.accessToken;
+    let refreshed = false;
+    const pageSize = Number(config.pageSize ?? 100);
+    const maxRecords = Number(options.maxRecords ?? config.maxRecords ?? 1000);
+
+    const formula = buildFilterFormula(config, options.since, options.filters);
+
+    const doRequest = async (url) => {
+      const response = await fetch(url, {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+      if (response.status === 401 && !refreshed && account.refreshToken) {
+        refreshed = true;
+        const tokens = await this.refreshToken(account.refreshToken);
+        if (tokens?.accessToken) {
+          account.accessToken = tokens.accessToken;
+          if (tokens.refreshToken) {
+            account.refreshToken = tokens.refreshToken;
+          }
+          if (tokens.expiresAt) {
+            account.expiresAt = tokens.expiresAt;
+          }
+          await account.save();
+          accessToken = account.accessToken;
+          return doRequest(url);
+        }
+      }
+      if (!response.ok) {
+        const errorBody = await response.text();
+        throw new Error(`Airtable API error (${response.status}): ${errorBody}`);
+      }
+      return response.json();
+    };
+
+    do {
+      const endpoint = new URL(`${API_BASE}/${config.baseId}/${encodeURIComponent(config.tableId)}`);
+      const search = endpoint.searchParams;
+      search.set('pageSize', String(pageSize));
+      if (offset) {
+        search.set('offset', offset);
+      }
+      if (formula) {
+        search.set('filterByFormula', formula);
+      }
+      if (config.viewId) {
+        search.set('view', config.viewId);
+      }
+      if (Array.isArray(config.fields)) {
+        for (const field of config.fields) {
+          search.append('fields[]', field);
+        }
+      }
+      if (Array.isArray(config.sort)) {
+        config.sort.forEach((entry, idx) => {
+          if (entry?.field) {
+            search.append(`sort[${idx}][field]`, entry.field);
+            if (entry.direction) {
+              search.append(`sort[${idx}][direction]`, entry.direction);
+            }
+          }
+        });
+      }
+
+      const payload = await doRequest(endpoint.toString());
+      const pageRecords = Array.isArray(payload.records) ? payload.records : [];
+      for (const record of pageRecords) {
+        const normalized = normalizeRecord(record, config);
+        if (options.since) {
+          const sinceDate = new Date(options.since);
+          if (normalized.updatedAt && normalized.updatedAt <= sinceDate) {
+            continue;
+          }
+        }
+        items.push(normalized);
+        if (items.length >= maxRecords) {
+          break;
+        }
+      }
+      offset = payload.offset;
+      if (items.length >= maxRecords) {
+        break;
+      }
+    } while (offset);
+
+    return {
+      items,
+      cursor: offset ? { offset } : undefined,
+    };
+  }
+}
+
+registerIntegration(new AirtableIntegration());

--- a/server/integrations/state.js
+++ b/server/integrations/state.js
@@ -1,0 +1,33 @@
+import { randomBytes } from 'node:crypto';
+import { getRedisBase } from '../redis.js';
+
+const STATE_PREFIX = 'integration:state:';
+const DEFAULT_TTL_SECONDS = 10 * 60;
+
+export async function createIntegrationState(payload, ttlSeconds = DEFAULT_TTL_SECONDS) {
+  const state = randomBytes(16).toString('hex');
+  const client = getRedisBase('integration-state');
+  await client.setEx(`${STATE_PREFIX}${state}`, ttlSeconds, JSON.stringify({
+    ...payload,
+    createdAt: new Date().toISOString(),
+  }));
+  return state;
+}
+
+export async function consumeIntegrationState(state) {
+  if (!state) {
+    return null;
+  }
+  const client = getRedisBase('integration-state');
+  const key = `${STATE_PREFIX}${state}`;
+  const json = await client.get(key);
+  if (!json) {
+    return null;
+  }
+  await client.del(key);
+  try {
+    return JSON.parse(json);
+  } catch (error) {
+    return null;
+  }
+}

--- a/server/job-worker.js
+++ b/server/job-worker.js
@@ -150,6 +150,8 @@ async function getQueueObject(type) {
             return (await import('./brightdata_queue.js'))
         case 'flow':
             return (await import('./flow_queue.js'))
+        case 'integration':
+            return (await import('./integration_queue.js'))
         default:
             throw new Error(`Unknown queue type: ${type}`);
     }

--- a/server/model/IntegrationAccount.js
+++ b/server/model/IntegrationAccount.js
@@ -1,0 +1,38 @@
+import mongoose from 'mongoose';
+
+const { Schema, model } = mongoose;
+
+const integrationAccountSchema = new Schema(
+  {
+    provider: { type: String, required: true },
+    userId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+    workspaceId: { type: Schema.Types.ObjectId, ref: 'Workspace', required: true },
+    accessToken: { type: String, required: true },
+    refreshToken: { type: String },
+    expiresAt: { type: Date },
+    scope: [{ type: String }],
+    metadata: Schema.Types.Mixed,
+  },
+  {
+    timestamps: true,
+    strict: false,
+  }
+);
+
+integrationAccountSchema.methods.toSafeObject = function toSafeObject() {
+  return {
+    id: this._id.toString(),
+    provider: this.provider,
+    userId: this.userId?.toString?.() ?? this.userId,
+    workspaceId: this.workspaceId?.toString?.() ?? this.workspaceId,
+    scope: this.scope ?? [],
+    expiresAt: this.expiresAt ?? null,
+    metadata: this.metadata ?? {},
+    createdAt: this.createdAt,
+    updatedAt: this.updatedAt,
+  };
+};
+
+const IntegrationAccount = model('IntegrationAccount', integrationAccountSchema);
+
+export default IntegrationAccount;

--- a/server/queue_registry.js
+++ b/server/queue_registry.js
@@ -9,6 +9,7 @@ const loaders = {
   query:     () => import('./query_queue.js'),
   brightdata:() => import('./brightdata_queue.js'),
   flow:      () => import('./flow_queue.js'),
+  integration: () => import('./integration_queue.js'),
 };
 
 export function registerQueue(name, instance) {

--- a/server/routes/integrations.js
+++ b/server/routes/integrations.js
@@ -1,0 +1,198 @@
+import express from 'express';
+import IntegrationQueue from '../integration_queue.js';
+import IntegrationAccount from '../model/IntegrationAccount.js';
+import { fetchPrimitive } from '../SharedFunctions.js';
+import { getIntegration, listIntegrations } from '../integrations/index.js';
+import { createIntegrationState, consumeIntegrationState } from '../integrations/state.js';
+
+const router = express.Router();
+
+function ensureWorkspaceAccess(req, workspaceId) {
+  if (!workspaceId) {
+    return false;
+  }
+  const ids = (req.user?.workspaceIds ?? []).map((id) => id.toString());
+  return ids.includes(workspaceId.toString());
+}
+
+router.get('/providers', (req, res) => {
+  res.json({ providers: listIntegrations() });
+});
+
+router.get('/accounts', async (req, res) => {
+  try {
+    const { provider, workspaceId } = req.query;
+    const filter = { userId: req.user._id };
+    if (provider) {
+      filter.provider = provider;
+    }
+    if (workspaceId) {
+      if (!ensureWorkspaceAccess(req, workspaceId)) {
+        return res.status(403).json({ error: 'Forbidden' });
+      }
+      filter.workspaceId = workspaceId;
+    } else {
+      filter.workspaceId = { $in: req.user.workspaceIds ?? [] };
+    }
+    const accounts = await IntegrationAccount.find(filter).lean();
+    res.json({
+      accounts: accounts.map((account) => ({
+        id: account._id.toString(),
+        provider: account.provider,
+        workspaceId: account.workspaceId?.toString?.() ?? account.workspaceId,
+        scope: account.scope ?? [],
+        expiresAt: account.expiresAt ?? null,
+        metadata: account.metadata ?? {},
+        createdAt: account.createdAt,
+        updatedAt: account.updatedAt,
+      })),
+    });
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+router.post('/external/:id/sync', async (req, res) => {
+  try {
+    const { id } = req.params;
+    const primitive = await fetchPrimitive(id, { workspaceId: { $in: req.user.workspaceIds ?? [] } });
+    if (!primitive) {
+      return res.status(404).json({ error: 'Primitive not found' });
+    }
+    if (primitive.type !== 'external') {
+      return res.status(400).json({ error: 'Primitive is not an external integration' });
+    }
+    await IntegrationQueue().enqueueSync(primitive, {
+      provider: req.body?.provider,
+      accountId: req.body?.accountId,
+      since: req.body?.since,
+    });
+    res.json({ queued: true });
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+router.get('/:provider/oauth/start', async (req, res) => {
+  try {
+    const { provider } = req.params;
+    const integration = getIntegration(provider);
+    if (!integration) {
+      return res.status(404).json({ error: 'Unknown integration provider' });
+    }
+    const workspaceId = req.query.workspaceId ?? req.user.workspaceIds?.[0];
+    if (!workspaceId) {
+      return res.status(400).json({ error: 'workspaceId is required' });
+    }
+    if (!ensureWorkspaceAccess(req, workspaceId)) {
+      return res.status(403).json({ error: 'Forbidden' });
+    }
+    const redirectUri = req.query.redirectUri || integration.defaultRedirectUri;
+    const scopes = req.query.scopes
+      ? String(req.query.scopes).split(',').map((s) => s.trim()).filter(Boolean)
+      : undefined;
+    const state = await createIntegrationState({
+      provider,
+      userId: req.user._id,
+      workspaceId,
+      redirectUri,
+      returnTo: req.query.returnTo,
+    });
+    const authorizationUrl = integration.getAuthorizationUrl({
+      state,
+      redirectUri,
+      scopes,
+    });
+    res.json({ authorizationUrl, state });
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+router.get('/:provider/oauth/callback', async (req, res) => {
+  try {
+    const { provider } = req.params;
+    const { code, state } = req.query;
+    if (!code || !state) {
+      return res.status(400).json({ error: 'Missing code or state' });
+    }
+    const integration = getIntegration(provider);
+    if (!integration) {
+      return res.status(404).json({ error: 'Unknown integration provider' });
+    }
+    const context = await consumeIntegrationState(state);
+    if (!context || context.provider !== provider) {
+      return res.status(400).json({ error: 'Invalid or expired state parameter' });
+    }
+    if (req.user?._id && context.userId && req.user._id.toString() !== context.userId.toString()) {
+      return res.status(403).json({ error: 'Forbidden' });
+    }
+    if (!ensureWorkspaceAccess({ user: req.user }, context.workspaceId)) {
+      return res.status(403).json({ error: 'Forbidden' });
+    }
+    const tokens = await integration.exchangeCodeForToken({
+      code,
+      redirectUri: context.redirectUri,
+    });
+    const update = {
+      provider,
+      userId: context.userId,
+      workspaceId: context.workspaceId,
+      accessToken: tokens.accessToken,
+      scope: Array.isArray(tokens.scope)
+        ? tokens.scope
+        : tokens.scope
+          ? String(tokens.scope).split(' ')
+          : integration.scopes,
+    };
+    if (tokens.refreshToken) {
+      update.refreshToken = tokens.refreshToken;
+    }
+    if (tokens.expiresAt) {
+      update.expiresAt = tokens.expiresAt;
+    } else if (tokens.expiresIn) {
+      update.expiresAt = new Date(Date.now() + Number(tokens.expiresIn) * 1000);
+    }
+    if (tokens.metadata) {
+      update.metadata = tokens.metadata;
+    }
+    const account = await IntegrationAccount.findOneAndUpdate(
+      { provider, userId: context.userId, workspaceId: context.workspaceId },
+      { $set: update },
+      { new: true, upsert: true, setDefaultsOnInsert: true },
+    );
+    const payload = {
+      success: true,
+      provider,
+      account: account.toSafeObject ? account.toSafeObject() : {
+        id: account._id.toString(),
+        provider: account.provider,
+        workspaceId: account.workspaceId?.toString?.() ?? account.workspaceId,
+        scope: account.scope ?? [],
+        expiresAt: account.expiresAt ?? null,
+        metadata: account.metadata ?? {},
+        createdAt: account.createdAt,
+        updatedAt: account.updatedAt,
+      },
+    };
+    if (context.returnTo) {
+      try {
+        const redirectUrl = new URL(context.returnTo);
+        redirectUrl.searchParams.set('integration', provider);
+        redirectUrl.searchParams.set('status', 'success');
+        redirectUrl.searchParams.set('accountId', payload.account.id);
+        return res.redirect(redirectUrl.toString());
+      } catch (err) {
+        // fall through to JSON response if redirect fails
+      }
+    }
+    res.json(payload);
+  } catch (error) {
+    if (req.query?.state) {
+      try { await consumeIntegrationState(req.query.state); } catch (_) { /* noop */ }
+    }
+    res.status(500).json({ error: error.message });
+  }
+});
+
+export default router;

--- a/ui/src/App.js
+++ b/ui/src/App.js
@@ -31,6 +31,7 @@ import { PrimitivePopup } from './PrimitivePopup.js';
 import ResetPasswordPage from './ResetPassword.js';
 import ProjectScreen from './ProjectScreen.js';
 import UsageScreen from './UsageScreen.js';
+import IntegrationsScreen from './IntegrationsScreen.jsx';
 import { QueuePage } from './QueuePage.jsx';
 import AccountScreen from './AccountScreen.js';
 
@@ -196,6 +197,7 @@ function App() {
                 </SideNav>}>
                   <Route path="/workflow/:id/new_instance" element={<FlowInstancePage />}/>
                   <Route path="/usage/" element={<UsageScreen />}/>
+                  <Route path="/integrations" element={<IntegrationsScreen />}/>
                   <Route path="/account/" element={<AccountScreen/>}/>
                   <Route path="/queue/:id?" element={<QueuePage />}/>
                   <Route path="/workflows/:id?" element={<WorkflowDashboard widePage={widePage} setWidePage={setWidePage}/>}/>

--- a/ui/src/IntegrationsScreen.jsx
+++ b/ui/src/IntegrationsScreen.jsx
@@ -1,0 +1,283 @@
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { Button, Card, CardBody, CardHeader, Chip, Divider, Spinner } from "@heroui/react";
+import toast from "react-hot-toast";
+import MainStore from "./MainStore";
+
+function formatDate(value) {
+  if (!value) {
+    return null;
+  }
+  try {
+    const date = value instanceof Date ? value : new Date(value);
+    if (Number.isNaN(date.getTime())) {
+      return null;
+    }
+    return date.toLocaleString();
+  } catch (error) {
+    return null;
+  }
+}
+
+export default function IntegrationsScreen() {
+  const mainstore = MainStore();
+  const [providers, setProviders] = useState([]);
+  const [accounts, setAccounts] = useState([]);
+  const [loadingProviders, setLoadingProviders] = useState(false);
+  const [loadingAccounts, setLoadingAccounts] = useState(false);
+  const [startingProvider, setStartingProvider] = useState(null);
+  const [pendingResult, setPendingResult] = useState(null);
+
+  const workspaceId = mainstore.activeWorkspaceId;
+  const workspace = workspaceId ? mainstore.workspace(workspaceId) : null;
+
+  const accountsByProvider = useMemo(() => {
+    const grouped = new Map();
+    for (const account of accounts) {
+      if (!account?.provider) continue;
+      if (!grouped.has(account.provider)) {
+        grouped.set(account.provider, []);
+      }
+      grouped.get(account.provider).push(account);
+    }
+    return grouped;
+  }, [accounts]);
+
+  const loadProviders = useCallback(async () => {
+    setLoadingProviders(true);
+    try {
+      const response = await fetch("/api/integrations/providers");
+      if (!response.ok) {
+        throw new Error(`Failed to fetch providers (${response.status})`);
+      }
+      const body = await response.json();
+      setProviders(Array.isArray(body?.providers) ? body.providers : []);
+    } catch (error) {
+      console.error(error);
+      toast.error(error.message || "Unable to load integration providers");
+    } finally {
+      setLoadingProviders(false);
+    }
+  }, []);
+
+  const loadAccounts = useCallback(async () => {
+    setLoadingAccounts(true);
+    try {
+      const search = new URLSearchParams();
+      if (workspaceId) {
+        search.set("workspaceId", workspaceId);
+      }
+      const response = await fetch(`/api/integrations/accounts${search.size ? `?${search.toString()}` : ""}`);
+      if (!response.ok) {
+        throw new Error(`Failed to fetch accounts (${response.status})`);
+      }
+      const body = await response.json();
+      setAccounts(Array.isArray(body?.accounts) ? body.accounts : []);
+    } catch (error) {
+      console.error(error);
+      toast.error(error.message || "Unable to load integration accounts");
+    } finally {
+      setLoadingAccounts(false);
+    }
+  }, [workspaceId]);
+
+  useEffect(() => {
+    loadProviders();
+  }, [loadProviders]);
+
+  useEffect(() => {
+    loadAccounts();
+  }, [loadAccounts]);
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    if (params.has("status") || params.has("integration") || params.has("accountId")) {
+      setPendingResult({
+        status: params.get("status"),
+        provider: params.get("integration"),
+        accountId: params.get("accountId"),
+      });
+      params.delete("status");
+      params.delete("integration");
+      params.delete("accountId");
+      const next = params.toString();
+      const nextUrl = `${window.location.pathname}${next ? `?${next}` : ""}${window.location.hash ?? ""}`;
+      window.history.replaceState({}, document.title, nextUrl);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!pendingResult) {
+      return;
+    }
+    if (pendingResult.status === "success") {
+      const providerInfo = providers.find((entry) => entry.name === pendingResult.provider);
+      const label = providerInfo?.title || providerInfo?.name || pendingResult.provider;
+      toast.success(`Connected to ${label || "integration"}`);
+      loadAccounts();
+    } else if (pendingResult.status && pendingResult.status !== "success") {
+      toast.error("Integration authorization failed");
+    }
+    setPendingResult(null);
+  }, [pendingResult, providers, loadAccounts]);
+
+  const startOAuth = useCallback(async (providerName) => {
+    if (!providerName) {
+      return;
+    }
+    if (!workspaceId) {
+      toast.error("Select a workspace before connecting an integration");
+      return;
+    }
+    setStartingProvider(providerName);
+    try {
+      const params = new URLSearchParams({ workspaceId });
+      const returnUrl = new URL(window.location.origin);
+      returnUrl.pathname = "/integrations";
+      returnUrl.search = "";
+      returnUrl.hash = "";
+      params.set("returnTo", returnUrl.toString());
+      const response = await fetch(`/api/integrations/${providerName}/oauth/start?${params.toString()}`);
+      if (!response.ok) {
+        throw new Error(`Failed to start authorization (${response.status})`);
+      }
+      const body = await response.json();
+      if (!body?.authorizationUrl) {
+        throw new Error("Missing authorization URL");
+      }
+      window.location.href = body.authorizationUrl;
+    } catch (error) {
+      console.error(error);
+      toast.error(error.message || "Unable to start authorization");
+      setStartingProvider(null);
+    }
+  }, [workspaceId]);
+
+  const renderProviderCard = (provider) => {
+    const providerAccounts = accountsByProvider.get(provider.name) ?? [];
+    const hasAccounts = providerAccounts.length > 0;
+
+    return (
+      <Card key={provider.name} shadow="sm" className="border border-default-200">
+        <CardHeader className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h2 className="text-large font-semibold text-foreground">{provider.title || provider.name}</h2>
+            {provider.description && (
+              <p className="mt-1 text-small text-default-500">{provider.description}</p>
+            )}
+            {provider.scopes?.length > 0 && (
+              <div className="mt-3 flex flex-wrap gap-2">
+                {provider.scopes.map((scope) => (
+                  <Chip key={scope} size="sm" variant="flat" color="secondary">
+                    {scope}
+                  </Chip>
+                ))}
+              </div>
+            )}
+          </div>
+          <Button
+            color="primary"
+            radius="full"
+            onPress={() => startOAuth(provider.name)}
+            isLoading={startingProvider === provider.name}
+          >
+            {hasAccounts ? "Connect another account" : "Connect"}
+          </Button>
+        </CardHeader>
+        <CardBody className="space-y-4">
+          {loadingAccounts && providerAccounts.length === 0 ? (
+            <div className="flex items-center gap-2 text-small text-default-500">
+              <Spinner size="sm" />
+              <span>Loading connections…</span>
+            </div>
+          ) : hasAccounts ? (
+            <div className="space-y-3">
+              {providerAccounts.map((account) => (
+                <div
+                  key={account.id}
+                  className="rounded-large border border-default-200 bg-default-100/50 p-4"
+                >
+                  <div className="flex flex-col gap-1 text-small">
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                      <span className="font-medium text-foreground">Authorized account</span>
+                      {account.expiresAt && (
+                        <Chip size="sm" variant="flat" color="success">
+                          Refreshes {formatDate(account.expiresAt)}
+                        </Chip>
+                      )}
+                    </div>
+                    <div className="text-default-500">
+                      Connected {formatDate(account.createdAt) || "recently"}
+                    </div>
+                    {account.scope?.length > 0 && (
+                      <div className="text-default-500">
+                        Scope: {account.scope.join(", ")}
+                      </div>
+                    )}
+                    {account.metadata && Object.keys(account.metadata).length > 0 && (
+                      <div className="text-default-500">
+                        {Object.entries(account.metadata).map(([key, value]) => (
+                          <div key={key}>
+                            <span className="font-medium capitalize">{key}:</span> {String(value)}
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                    <div className="text-default-400">
+                      Updated {formatDate(account.updatedAt) || formatDate(account.createdAt) || "recently"}
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="text-small text-default-500">
+              No accounts connected yet. Use the Connect button to authorize access.
+            </p>
+          )}
+        </CardBody>
+      </Card>
+    );
+  };
+
+  return (
+    <div className="flex h-full w-full justify-center overflow-y-auto bg-content1">
+      <div className="flex w-full max-w-4xl flex-col gap-6 p-6">
+        <header className="flex flex-col gap-2">
+          <h1 className="text-2xl font-semibold text-foreground">Integrations</h1>
+          <p className="text-small text-default-500">
+            Connect external data sources to sync records into your workspace.
+          </p>
+          {workspace && (
+            <p className="text-small text-default-400">
+              Managing connections for <span className="font-medium text-default-500">{workspace.title}</span>
+            </p>
+          )}
+          {!workspaceId && (
+            <Chip color="warning" variant="flat" size="sm" className="w-fit">
+              Select a workspace to enable connections
+            </Chip>
+          )}
+        </header>
+
+        <Divider />
+
+        {loadingProviders && providers.length === 0 ? (
+          <div className="flex items-center gap-2 text-small text-default-500">
+            <Spinner size="sm" />
+            <span>Loading providers…</span>
+          </div>
+        ) : providers.length > 0 ? (
+          providers.map((provider) => renderProviderCard(provider))
+        ) : (
+          <Card className="border border-default-200" shadow="sm">
+            <CardBody>
+              <p className="text-small text-default-500">
+                No integrations are currently available. Check back soon for new connection options.
+              </p>
+            </CardBody>
+          </Card>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/ui/src/PrimitiveConfig.js
+++ b/ui/src/PrimitiveConfig.js
@@ -329,6 +329,10 @@ const PrimitiveConfig = {
             needCategory:false,
             defaultTitle: false
         },
+        "external": {
+            needCategory:false,
+            defaultTitle:false,
+        },
     },
     types: ["hypothesis", 
         "learning",
@@ -361,7 +365,8 @@ const PrimitiveConfig = {
         "categorizer",
         "action",
         "page",
-        "chat"
+        "chat",
+        "external"
     ],
     pageview:{
         "board":{

--- a/ui/src/SideNav.js
+++ b/ui/src/SideNav.js
@@ -44,6 +44,7 @@ const navigation = [
   { name: 'Home', onClick: ()=>{navigate('/')}, icon: HomeIcon, current: urlPath === "" || urlPath === "/" },
   mainstore.activeWorkspaceId && !mainstore.activeUser.info.external && { name: 'Project Home', onClick: ()=>{navigate(`/project/${mainstore.activeWorkspaceId}`)}, icon: SparklesIcon, current: urlPath.includes("/project")},
   { name: 'Workflows', onClick: ()=>{navigate(mainstore.activeWorkspaceId ?  `/workflows/${mainstore.activeWorkspaceId}` : undefined)}, icon: SparklesIcon, current: urlPath.includes("/workflows")},
+  { name: 'Integrations', onClick: ()=>{navigate('/integrations')}, icon: Bars4Icon, current: urlPath.includes("/integrations")},
   { name: 'Usage', onClick: ()=>{navigate('/usage')}, icon: ArrowDownTrayIcon, current: urlPath.includes("/usage") },
 ].filter(Boolean)
 


### PR DESCRIPTION
## Summary
- deduplicate external record syncs by querying parent relationships instead of cached integration resource maps
- tag mapped child primitives with integration mapping keys and remove stale resource blobs from synced records
- keep sync timestamps and cursors in reference parameters while clearing obsolete integration resource state

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68df5c6364c08330a3246cc04371ee66