### PR TITLE
Simplify primitive plain text ingestion

### DIFF
--- a/server/DocumentSearch.js
+++ b/server/DocumentSearch.js
@@ -1,5 +1,5 @@
 import { encode } from "gpt-3-encoder";
-import { getDocumentAsPlainText } from "./google_helper";
+import { getPrimitiveContentPlainText } from "./google_helper";
 import Category from "./model/Category";
 import ContentEmbedding from "./model/ContentEmbedding";
 import { buildEmbeddings } from "./openai_helper";
@@ -48,7 +48,7 @@ export async function indexDocument( primitive, {force, fetch} = {}, req){
         }
         
         if( !text ){
-            text = (await getDocumentAsPlainText( primitive.id, req, undefined, false, fetch ))?.plain
+            text = (await getPrimitiveContentPlainText( primitive.id, { req, forceRefresh: fetch }))?.plain
             //text = (await getDocumentAsPlainText( primitive.id, req ))?.plain
         }
         if( !text || text.length === 0){


### PR DESCRIPTION
## Summary
- add a new getPrimitiveContentPlainText helper that centralizes primitive content lookups, including cache, context, Google Drive, and URL handling
- refactor getDocumentAsPlainText to delegate to the new helper and update DocumentSearch to rely on the shared retrieval path

## Testing
- npm test *(fails: jest-haste-map naming collision between root package.json and ui/package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68de387797448330a6bd9889027b15b3